### PR TITLE
Adds get the AMD GPU model

### DIFF
--- a/src/systeminfo/systeminfo.go
+++ b/src/systeminfo/systeminfo.go
@@ -5,6 +5,7 @@ import (
 	"OpenLinkHub/src/logger"
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -113,8 +114,7 @@ func (si *SystemInfo) getGpuData() {
 			return
 		} else if strings.Contains(line, "VGA compatible controller") && strings.Contains(line, "Advanced Micro Devices") {
 			// AMD
-			// To-Do: Find proper AMD GPU model
-			si.GPU = &GpuData{Model: "AMD Compatible GPU"}
+			si.GPU = &GpuData{Model: GetAMDGpuModels()[0]}
 			return
 		} else {
 			si.GPU = nil
@@ -195,6 +195,31 @@ func GetNVIDIAGpuModel() string {
 	}
 	model = strings.TrimSpace(string(output))
 	return model
+}
+
+func GetAMDGpuModels() ([]string, error) {
+	var data map[string]map[string]interface{}
+	cmd := exec.Command("rocm-smi", "--showallinfo", "--json")
+	jsonOutput, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("error executing rocm-smi: %v", err)
+	}
+
+	err = json.Unmarshal(jsonOutput, &data)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshaling JSON: %v", err)
+	}
+
+	var models []string
+	for key, value := range data {
+		if strings.HasPrefix(key, "card") {
+			if deviceName, ok := value["Device Name"].(string); ok {
+				models = append(models, deviceName)
+			}
+		}
+	}
+
+	return models, nil
 }
 
 // GetNVIDIAUtilization will return NVIDIA gpu utilization

--- a/src/systeminfo/systeminfo.go
+++ b/src/systeminfo/systeminfo.go
@@ -113,8 +113,11 @@ func (si *SystemInfo) getGpuData() {
 			si.GPU = &GpuData{Model: GetNVIDIAGpuModel()}
 			return
 		} else if strings.Contains(line, "VGA compatible controller") && strings.Contains(line, "Advanced Micro Devices") {
-			// AMD
-			si.GPU = &GpuData{Model: GetAMDGpuModels()[0]}
+			// AMD Models for now just use first one
+			models, err := GetAMDGpuModels()
+			if err == nil && len(models) > 0 {
+				si.GPU = &GpuData{Model: models[0]}
+			}
 			return
 		} else {
 			si.GPU = nil


### PR DESCRIPTION
This gets all the models and puts them in a slice, but currently only references the first element.

Example output from `rocsm-smi`

```json
{
  "card0": {
    "Device Name": "Navi 31 [Radeon RX 7900 XT/7900 XTX/7900 GRE/7900M]",
    "Device ID": "0x744c",
    "Device Rev": "0xce",
    "Subsystem ID": "0x5315",
    "GUID": "62766",
    "Unique ID": "0x3d4595974090853c",
    "VBIOS version": "113-APM7199-002",
    "Temperature (Sensor edge) (C)": "46.0",
    "Temperature (Sensor junction) (C)": "52.0",
    "Temperature (Sensor memory) (C)": "58.0",
    "dcefclk clock speed:": "(409Mhz)",
    "dcefclk clock level:": "1",
    "fclk clock speed:": "(1200Mhz)",
    "fclk clock level:": "3",
    "mclk clock speed:": "(96Mhz)",
    "mclk clock level:": "0",
    "sclk clock speed:": "(34Mhz)",
    "sclk clock level:": "1",
    "socclk clock speed:": "(750Mhz)",
    "socclk clock level:": "1",
    "pcie clock level": "2 (16.0GT/s x16)",
    "Performance Level": "auto",
    "Max Graphics Package Power (W)": "220.0",
    "Average Graphics Package Power (W)": "17.0",
    "GPU use (%)": "1",
    "GPU Memory Allocated (VRAM%)": "14",
    "GPU Memory Read/Write Activity (%)": "2",
    "Memory Activity": "N/A",
    "Avg. Memory Bandwidth": "0",
    "GPU memory vendor": "samsung",
    "PCIe Replay Count": "0",
    "Serial Number": "N/A",
    "Voltage (mV)": "58",
    "PCI Bus": "0000:03:00.0",
    "ASD firmware version": "0x210000e3",
    "ME firmware version": "2280",
    "MEC firmware version": "2420",
    "MES firmware version": "0x00000069",
    "MES KIQ firmware version": "0x00000100",
    "PFP firmware version": "2360",
    "RLC firmware version": "13",
    "SDMA firmware version": "24",
    "SDMA2 firmware version": "24",
    "SMC firmware version": "00.78.126.00",
    "SOS firmware version": "0x00310032",
    "TA RAS firmware version": "27.00.02.05",
    "VCN firmware version": "0x09116003",
    "Card Series": "Navi 31 [Radeon RX 7900 XT/7900 XTX/7900 GRE/7900M]",
    "Card Model": "0x744c",
    "Card Vendor": "Advanced Micro Devices, Inc. [AMD/ATI]",
    "Card SKU": "APM7199",
    "Node ID": "1",
    "GFX Version": "gfx11000",
    "Energy counter": "0",
    "Accumulated Energy (uJ)": "0.0"
  },
  "card1": {
    "Device Name": "Raphael",
    "Device ID": "0x164e",
    "Device Rev": "0xc1",
    "Subsystem ID": "0x364e",
    "GUID": "47325",
    "Unique ID": "N/A",
    "VBIOS version": "102-RAPHAEL-008",
    "Temperature (Sensor edge) (C)": "40.0",
    "mclk clock speed:": "(3000Mhz)",
    "mclk clock level:": "0",
    "sclk clock speed:": "(600Mhz)",
    "sclk clock level:": "1",
    "socclk clock speed:": "(1200Mhz)",
    "socclk clock level:": "1",
    "Performance Level": "auto",
    "Current Socket Graphics Package Power (W)": "6.207",
    "GPU use (%)": "0",
    "GPU Memory Allocated (VRAM%)": "6",
    "Memory Activity": "N/A",
    "PCIe Replay Count": "0",
    "Serial Number": "N/A",
    "Voltage (mV)": "1400",
    "PCI Bus": "0000:59:00.0",
    "ASD firmware version": "0x210000e3",
    "CE firmware version": "3",
    "ME firmware version": "14",
    "MEC firmware version": "21",
    "MEC2 firmware version": "21",
    "PFP firmware version": "14",
    "RLC firmware version": "31",
    "RLC SRLC firmware version": "1",
    "RLC SRLG firmware version": "1",
    "RLC SRLS firmware version": "1",
    "SDMA firmware version": "9",
    "SMC firmware version": "00.84.79.225",
    "VCN firmware version": "0x0311f003",
    "Card Series": "Raphael",
    "Card Model": "0x164e",
    "Card Vendor": "Advanced Micro Devices, Inc. [AMD/ATI]",
    "Card SKU": "RAPHAEL",
    "Node ID": "2",
    "GFX Version": "gfx1036",
    "Valid sclk range": "400Mhz - 2200Mhz",
    "Valid mclk range": "0Mhz - 0Mhz"
  },
  "system": {
    "Driver version": "6.11.8-zen1-2-zen"
  }
}
```