### PR TITLE
Correct support for systemd-sleep

### DIFF
--- a/OpenLinkHub.service
+++ b/OpenLinkHub.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Open source interface for iCUE LINK System Hub, Corsair AIOs and Hubs
+After=sleep.target
 
 [Service]
 User=nikola

--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@ else
         cat > $SYSTEMD_FILE <<- EOM
 [Unit]
 Description=Open source interface for iCUE LINK System Hub, Corsair AIOs and Hubs
-After=multi-user.target
+After=sleep.target
 
 [Service]
 User=$USER_TO_CHECK
@@ -70,7 +70,7 @@ echo "Creating systemd file..."
 cat > $SYSTEMD_FILE <<- EOM
 [Unit]
 Description=Open source interface for iCUE LINK System Hub, Corsair AIOs and Hubs
-After=multi-user.target
+After=sleep.target
 
 [Service]
 User=$USER_TO_CHECK


### PR DESCRIPTION
### Background
I noticed the service declared `[Unit] After=multi-user.target` and would fail to restart following a `systemd-sleep` events. The service correctly starts on a fresh boot, but would not be triggered by a `sleep.target` trigger _(suspend, hibernate, hybrid, etc...)._ 

The service should only start after a successful boot (at-least `multi-user.target`), but still requires a dependency trigger on `sleep.target` to restart on wake.

----
>` [Install] WantedBy=` ... has the effect of a dependency of type `Wants=, Requires=, or Upholds=` being added from the listed unit to the current unit. [[1]](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#WantedBy=) 
> Additionally, `multi-user.target` is triggered after `poweroff.target` & `rescue.target`, but not triggered again after `sleep.target` [[2]](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#WantedBy=) [[3]](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#WantedBy=)
----

### Changes
Full support for restarting after `systemd-sleep`  should just require `After=sleep.target` added to the service's `[Unit]` section. This change should safely and reliably request OpenLinkHub to resume after `sleep.target` without effecting systemd's critical chain. This should avoid having to be overly complex in handling the `boot->sleep->wake->shutdown` cycle, and for systemd to "want" the service to start on boot (not require it) and to also restart the service after resuming from any sleep state.

```
[Unit]
After=sleep.target

[Service]
...

[Install]
WantedBy=multi-user.target
```