### PR TITLE
Add configuration for logger

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -3,25 +3,28 @@ package config
 import (
 	"OpenLinkHub/src/common"
 	"encoding/json"
+	log "github.com/sirupsen/logrus"
 	"os"
 )
 
 type Configuration struct {
-	Debug           bool     `json:"debug"`
-	ListenPort      int      `json:"listenPort"`
-	ListenAddress   string   `json:"listenAddress"`
-	CPUSensorChip   string   `json:"cpuSensorChip"`
-	Manual          bool     `json:"manual"`
-	Frontend        bool     `json:"frontend"`
-	Metrics         bool     `json:"metrics"`
-	Memory          bool     `json:"memory"`
-	MemorySmBus     string   `json:"memorySmBus"`
-	MemoryType      int      `json:"memoryType"`
-	Exclude         []uint16 `json:"exclude"`
-	DecodeMemorySku bool     `json:"decodeMemorySku"`
-	MemorySku       string   `json:"memorySku"`
-	ConfigPath      string   `json:",omitempty"`
-	ResumeDelay     int      `json:"resumeDelay"`
+	Debug           bool      `json:"debug"`
+	ListenPort      int       `json:"listenPort"`
+	ListenAddress   string    `json:"listenAddress"`
+	CPUSensorChip   string    `json:"cpuSensorChip"`
+	Manual          bool      `json:"manual"`
+	Frontend        bool      `json:"frontend"`
+	Metrics         bool      `json:"metrics"`
+	Memory          bool      `json:"memory"`
+	MemorySmBus     string    `json:"memorySmBus"`
+	MemoryType      int       `json:"memoryType"`
+	Exclude         []uint16  `json:"exclude"`
+	DecodeMemorySku bool      `json:"decodeMemorySku"`
+	MemorySku       string    `json:"memorySku"`
+	ConfigPath      string    `json:",omitempty"`
+	ResumeDelay     int       `json:"resumeDelay"`
+	LogFile         string    `json:"logFile,omitempty"`
+	LogLevel        log.Level `json:"logLevel"`
 }
 
 var (
@@ -31,6 +34,7 @@ var (
 		"decodeMemorySku": true,
 		"memorySku":       "",
 		"resumeDelay":     15000,
+		"logLevel":        log.InfoLevel,
 	}
 )
 

--- a/src/logger/logger.go
+++ b/src/logger/logger.go
@@ -10,13 +10,20 @@ type Fields = log.Fields
 
 // Init will initialize new instance of logger
 func Init() {
-	logFilename := config.GetConfig().ConfigPath + "/stdout.log"
 	log.SetFormatter(&log.JSONFormatter{})
-	file, err := os.OpenFile(logFilename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
-	if err == nil {
-		log.SetOutput(file)
-	} else {
-		log.Info("Failed to log to file, using default stderr")
+	log.SetLevel(config.GetConfig().LogLevel)
+
+	logFilename := config.GetConfig().LogFile
+	if logFilename == "" {
+		logFilename = config.GetConfig().ConfigPath + "/stdout.log"
+	}
+	if logFilename != "-" {
+		file, err := os.OpenFile(logFilename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+		if err == nil {
+			log.SetOutput(file)
+		} else {
+			log.WithFields(log.Fields{"error": err}).Warn("Failed to log to file, using default stderr")
+		}
 	}
 }
 


### PR DESCRIPTION
Makes it possible to configure
 * log file (or explicit stderr logging using "-")
 * log level

Log level doesn't do much but I think it's a sensible thing to have.

On a related note it would be more idiomatic to use `log.Debug` and let logrus sort it out rather than using a custom `if d.Debug { ... }`. It's a more controversial change though and maybe there's some context I'm missing that makes that preferable.

If you think it's a good idea I can add that too