### PR TITLE
Update README to replace hardcoded version numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,10 @@ Manage RGB lighting, fan speeds, system metrics, as well as keyboards, mice, hea
 3. Navigate to the folder where the package is downloaded
 ```bash
 # Debian Based (deb)
-$ sudo apt install ./OpenLinkHub_X.X.X_amd64.deb 
+$ sudo apt install ./OpenLinkHub_?.?.?_amd64.deb 
 
 # RPM based (rpm)
-$ sudo dnf install ./OpenLinkHub-X.X.X-1.x86_64.rpm
+$ sudo dnf install ./OpenLinkHub-?.?.?-1.x86_64.rpm
 ```
 
 ## Installation (manual)
@@ -144,7 +144,7 @@ $ sudo ./install.sh
 ```bash
 # Download latest build from https://github.com/jurkovic-nikola/OpenLinkHub/releases/latest
 $ wget "https://github.com/jurkovic-nikola/OpenLinkHub/releases/latest/download/OpenLinkHub_$(curl -s https://api.github.com/repos/jurkovic-nikola/OpenLinkHub/releases/latest | jq -r '.tag_name')_amd64.tar.gz"
-$ tar xf OpenLinkHub_*_amd64.tar.gz
+$ tar xf OpenLinkHub_?.?.?_amd64.tar.gz
 $ cd /home/$USER/OpenLinkHub/
 $ chmod +x install.sh
 $ sudo ./install.sh
@@ -157,7 +157,7 @@ $ sudo ./install.sh
 $ wget "https://github.com/jurkovic-nikola/OpenLinkHub/releases/latest/download/OpenLinkHub_$(curl -s https://api.github.com/repos/jurkovic-nikola/OpenLinkHub/releases/latest | jq -r '.tag_name')_amd64.tar.gz"
 
 # Extract package to your home directory
-$ tar xf OpenLinkHub_*_amd64.tar.gz -C /home/$USER/
+$ tar xf OpenLinkHub_?.?.?_amd64.tar.gz -C /home/$USER/
 
 # Go to extract folder
 $ cd /home/$USER/OpenLinkHub

--- a/README.md
+++ b/README.md
@@ -142,23 +142,22 @@ $ sudo ./install.sh
 
 ### 3. Installation from compiled build
 ```bash
-# Download latest build from https://github.com/jurkovic-nikola/OpenLinkHub/releases
-$ wget https://github.com/jurkovic-nikola/OpenLinkHub/releases/download/0.2.0/OpenLinkHub_0.2.0_amd64.tar.gz
-$ tar xvf OpenLinkHub_0.2.0_amd64.tar.gz
-$ cd OpenLinkHub/
+# Download latest build from https://github.com/jurkovic-nikola/OpenLinkHub/releases/latest
+$ wget "https://github.com/jurkovic-nikola/OpenLinkHub/releases/latest/download/OpenLinkHub_$(curl -s https://api.github.com/repos/jurkovic-nikola/OpenLinkHub/releases/latest | jq -r '.tag_name')_amd64.tar.gz"
+$ tar xf OpenLinkHub_*_amd64.tar.gz
+$ cd /home/$USER/OpenLinkHub/
 $ chmod +x install.sh
 $ sudo ./install.sh
 ```
 ### 4. Immutable distributions (Bazzite OS, SteamOS, etc...)
 ```bash
-# Do not install RPM or DEB packages on immutable distributions, they will not work. 
-# Download latest tar.gz from Release page. URL will be different when new version is released. 
-# To copy download link, go to https://github.com/jurkovic-nikola/OpenLinkHub/releases and right click on tar.gz file and Copy link address. 
-# Open your terminal application and type wget and paste copied link to download package. 
-$ wget https://github.com/jurkovic-nikola/OpenLinkHub/releases/download/0.4.7/OpenLinkHub_0.4.7_amd64.tar.gz
+# Do not install RPM or DEB packages on immutable distributions, they will not work.
+# This same procedure may be followed to update an existing installation.
+# Download the latest tar.gz from the Release page, or use the following command to download the latest release.
+$ wget "https://github.com/jurkovic-nikola/OpenLinkHub/releases/latest/download/OpenLinkHub_$(curl -s https://api.github.com/repos/jurkovic-nikola/OpenLinkHub/releases/latest | jq -r '.tag_name')_amd64.tar.gz"
 
 # Extract package to your home directory
-$ tar xf OpenLinkHub_X.X.X_amd64.tar.gz -C /home/$USER/
+$ tar xf OpenLinkHub_*_amd64.tar.gz -C /home/$USER/
 
 # Go to extract folder
 $ cd /home/$USER/OpenLinkHub


### PR DESCRIPTION
This updates various provided sample commands to use single-character wildcards instead of X.X.X, and updates download links to automatically pull the latest version. This should allow directly copy-pasted commands to work even as new versions are released.