### PR TITLE
feat(scimitar): support press-and-hold for all buttons and multi-button pressing

### DIFF
--- a/src/devices/scimitar/scimitar.go
+++ b/src/devices/scimitar/scimitar.go
@@ -1735,10 +1735,10 @@ func (d *Device) triggerKeyAssignment(value uint32) {
 		if isPressed {
 			if mask == 0x08 && val.Default {
 				d.ModifyDpi()
-				return
+				continue
 			}
 			if val.Default {
-				return
+				continue
 			}
 
 			switch val.ActionType {

--- a/src/inputmanager/inputmanager.go
+++ b/src/inputmanager/inputmanager.go
@@ -578,6 +578,37 @@ func createInputEvent(code uint16, hold bool) []inputEvent {
 	return events
 }
 
+func createInputEventHold(code uint16, press bool) []inputEvent {
+	// Synchronization event
+	syncEvent := inputEvent{
+		Type:  evSyn,
+		Code:  0,
+		Value: 0,
+	}
+
+	var events []inputEvent
+
+	// Only release if hold is false
+	if press {
+		// Create an input event for key press
+		keyPress := inputEvent{
+			Type:  evKey,
+			Code:  code,
+			Value: 1, // Key press
+		}
+		events = []inputEvent{keyPress, syncEvent}
+	} else {
+		// Create an input event for key release
+		keyRelease := inputEvent{
+			Type:  evKey,
+			Code:  code,
+			Value: 0,
+		}
+		events = []inputEvent{keyRelease, syncEvent}
+	}
+	return events
+}
+
 // writeVirtualEvent will send event to virtual keyboard device
 func writeVirtualEvent(f *os.File, event *inputEvent) error {
 	if f == nil {

--- a/src/inputmanager/keyboard.go
+++ b/src/inputmanager/keyboard.go
@@ -119,3 +119,30 @@ func InputControlKeyboard(controlType uint16, hold bool) {
 		}
 	}
 }
+
+// InputControlKeyboard will emulate input events based on virtual keyboard
+func InputControlKeyboardHold(controlType uint16, press bool) {
+	if virtualKeyboardFile == nil {
+		logger.Log(logger.Fields{}).Error("Virtual keyboard is not present")
+		return
+	}
+
+	var events []inputEvent
+
+	// Get event key code
+	actionType := getInputAction(controlType)
+	if actionType == nil {
+		return
+	}
+
+	// Create events
+	events = createInputEventHold(actionType.CommandCode, press)
+
+	// Send events
+	for _, event := range events {
+		if err := writeVirtualEvent(virtualKeyboardFile, &event); err != nil {
+			logger.Log(logger.Fields{"error": err}).Error("Failed to emit event")
+			return
+		}
+	}
+}

--- a/src/inputmanager/mouse.go
+++ b/src/inputmanager/mouse.go
@@ -129,7 +129,7 @@ func InputControlMouse(controlType uint16) {
 
 // InputControlMouseHold will emulate input events based on virtual mouse and button hold.
 // Experimental for now
-func InputControlMouseHold(controlType uint16, hold bool) {
+func InputControlMouseHold(controlType uint16, press bool) {
 	if virtualMouseFile == nil {
 		logger.Log(logger.Fields{}).Error("Virtual keyboard is not present")
 		return
@@ -143,7 +143,7 @@ func InputControlMouseHold(controlType uint16, hold bool) {
 	}
 
 	// Create events
-	events = createInputEvent(actionType.CommandCode, hold)
+	events = createInputEventHold(actionType.CommandCode, press)
 
 	// Send events
 	for _, event := range events {


### PR DESCRIPTION
Fixes #134

Re-implements key assignment triggering for the scimitar by tracking the previously set bits and diffing them with the new value to determine which buttons are newly pressed down and which are newly released.

For press-and-hold key assignments, when they are initially pressed we generate a press and sync event same as before, but now we precisely track when the buttons are released and when that happens we only generate the key release and sync rather than an extra press, sync, release, sync.