### PR TITLE
Update OpenLinkHub.service with auto restart

### DIFF
--- a/OpenLinkHub.service
+++ b/OpenLinkHub.service
@@ -8,6 +8,7 @@ WorkingDirectory=/opt/OpenLinkHub
 ExecStart=/opt/OpenLinkHub/OpenLinkHub
 ExecReload=/bin/kill -s HUP $MAINPID
 RestartSec=5
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I've tested this on my local system. After a startup from suspend the application failed. So it need to be told to auto restart. It would also be good to handle the error I faced during a restore from suspend, but this is a good catch all for any random issues.

P.S. this is the issue I saw int he logs after starting from suspend
```panic: invalid or incomplete multibyte or wide character```
