### PR TITLE
Nvidia vfio igpu

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ $ systemctl reboot
 - ramTempViaHwmon: Switch to true if you want to monitor RAM temperature via hwmon system. With this option, you don't have to unload modules to get temperature. (Require 6.11+ kernel)
 - nvidiaGpuIndex: NVIDIA multi gpu setup. 
 - defaultNvidiaGPU: default index of NVIDIA gpu, default is 0.
+  - If you use vfio-pci/pass-through, you have to set it to -1 to avoid conflits with nvidia modules.
 
 ### 6. Progressive Web App (PWA) UI
 The web UI supports installation as a progressive web app (PWA). With a supported browser, this allows the UI to appear as a standalone application.

--- a/src/systeminfo/systeminfo.go
+++ b/src/systeminfo/systeminfo.go
@@ -149,7 +149,7 @@ func (si *SystemInfo) getGpuData() {
 	for scanner.Scan() {
 		line := scanner.Text()
 		gpus := make(map[int]GpuData)
-		if strings.Contains(line, "VGA compatible controller") && strings.Contains(line, "NVIDIA") {
+		if strings.Contains(line, "VGA compatible controller") && strings.Contains(line, "NVIDIA") && config.GetConfig().DefaultNvidiaGPU != -1 {
 			// NVIDIA
 			for key := range config.GetConfig().NvidiaGpuIndex {
 				gpuModel := GetNVIDIAGpuModel(key)

--- a/src/systeminfo/systeminfo.go
+++ b/src/systeminfo/systeminfo.go
@@ -167,10 +167,26 @@ func (si *SystemInfo) getGpuData() {
 			si.GPU = gpus
 			return
 		} else if strings.Contains(line, "VGA compatible controller") && strings.Contains(line, "Advanced Micro Devices") {
+			gpuModel := GetAMDGpuModel()
+			if len(gpuModel) == 0 {
+				lineSplit := strings.Split(line, "[")
+				// if lspci gives [my]i[gpu]... return "myigpu"
+				// otherwise if gives [my gpu] returns "my gpu"
+				if len(lineSplit) >= 3 {
+					before, after, found := strings.Cut(lineSplit[1], "]")
+					if !found {
+						continue
+					}
+					gpuModel = before + after + lineSplit[2]
+				} else {
+					gpuModel = lineSplit[1]
+				}
+				gpuModel = strings.Split(gpuModel, "]")[0]
+			}
 			temp := temperatures.GetAMDGpuTemperature()
 			model := &GpuData{
 				Index:             0,
-				Model:             GetAMDGpuModel(),
+				Model:             gpuModel,
 				Temperature:       temp,
 				TemperatureString: dashboard.GetDashboard().TemperatureToString(temp),
 			}

--- a/src/temperatures/temperatures.go
+++ b/src/temperatures/temperatures.go
@@ -731,6 +731,10 @@ func GetAMDGpuTemperature() float32 {
 
 // GetNVIDIAGpuTemperature will return NVIDIA gpu temperature
 func GetNVIDIAGpuTemperature(gpuIndex int) float32 {
+	if config.GetConfig().DefaultNvidiaGPU == -1 {
+		return 0
+	}
+
 	cmd := exec.Command("nvidia-smi", "-i", strconv.Itoa(gpuIndex), "--query-gpu=temperature.gpu", "--format=csv,noheader,nounits")
 	output, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
1) fix module conflicts between vfio and nvidia by avoiding nvidia-smi
> [marin@pc-linux openlinkhub]$ sudo dmesg | grep -iE "vfio|10de" | tail
> [10582.980815] NVRM: GPU 0000:01:00.0 is already bound to vfio-pci.
> (install new version openlinkhub)
> [marin@pc-linux openlinkhub]$ sudo systemctl restart openlinkhub
> (sleep a bit)
> [marin@pc-linux openlinkhub]$ sudo dmesg | grep -iE "vfio|10de" | tail
> [10582.980815] NVRM: GPU 0000:01:00.0 is already bound to vfio-pci.
2) fix empty device name on dashboard

> 79:00.0 VGA compatible controller: Advanced Micro Devices, Inc. [AMD/ATI] Granite Ridge [Radeon Graphics] (rev c1)

<img width="1142" height="249" alt="Screenshot_20250806_113205" src="https://github.com/user-attachments/assets/b000c916-27c5-4839-a1a5-d18d9cee9656" />
