### PR TITLE
Fixes issue where /api/ endpoint was unaccesible due to json marshal ...

### DIFF
--- a/src/common/common.go
+++ b/src/common/common.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"golang.org/x/image/draw"
 	"image"
 	"image/gif"
 	"io"
@@ -18,6 +17,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"golang.org/x/image/draw"
 )
 
 type Device struct {
@@ -27,7 +28,7 @@ type Device struct {
 	Firmware    string
 	Image       string
 	GetDevice   interface{}
-	Instance    interface{}
+	Instance    interface{} `json:"-"`
 	Hidden      bool
 }
 


### PR DESCRIPTION
…error with some devices.

Error looked like this:
```
&{0xc006f165a0 0xc004a1a140 {} 0x637820 true false false {{} {0 0}} {{} 0} 0xc00b6f03c0 {0xc00490f590 map[Content-Type:[application/json]] false false} map[Content-Type:[application/json]] true 0 -1 200 false false false [] {{} 0} [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] [0 0 0 0 0 0 0 0 0 0] [0 0 0] {{} {0 0}} <nil> false} json: unsupported type: func(*common.Device)
```

I encontered it when tried to use openlinkhub-tray and it didn't open, when I check what is going on - api didn't return any response.