### PR TITLE
Create docker from release tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,74 @@
+name: Docker
+
+on:
+  push:
+    tags: [ '*.*.*' ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v3.8.1
+        with:
+          cosign-release: 'v2.4.3'
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args:
+            GIT_TAG=${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM golang:1.23.8-bullseye AS build
 ARG GIT_TAG
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y libudev-dev
+RUN apt-get update && apt-get install -y libudev-dev i2c-tools
+RUN mkdir -p /opt/OpenLinkHub
 
 WORKDIR /app
 RUN git clone https://github.com/jurkovic-nikola/OpenLinkHub.git
@@ -14,15 +15,19 @@ FROM debian:bullseye-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
-    apt-get install -y libudev-dev pciutils usbutils && \
+    apt-get install -y libudev-dev pciutils usbutils udev i2c-tools && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /opt/OpenLinkHub
+RUN mkdir -p /etc/modules-load.d
+RUN echo 'KERNEL=="i2c-0", MODE="0600", OWNER="openlinkhub"' | tee /etc/udev/rules.d/98-corsair-memory.rules
+RUN echo "i2c-dev" | tee /etc/modules-load.d/i2c-dev.conf
+
 COPY --from=build /app/OpenLinkHub/OpenLinkHub /opt/OpenLinkHub/
 COPY --from=build /app/OpenLinkHub/database /opt/OpenLinkHub/database
 COPY --from=build /app/OpenLinkHub/static /opt/OpenLinkHub/static
 COPY --from=build /app/OpenLinkHub/web /opt/OpenLinkHub/web
+COPY --from=build /app/OpenLinkHub/99-openlinkhub.rules /etc/udev/rules.d/99-openlinkhub.rules
 
 WORKDIR /opt/OpenLinkHub
 


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow for building and publishing Docker images, and updates the `Dockerfile` to improve hardware support (particularly for I2C devices) and device permissions. The changes ensure that the Docker image is built and pushed automatically on tag pushes, and that it is better equipped for hardware integration.

**CI/CD Automation:**

* Added a new workflow `.github/workflows/docker-publish.yml` to automatically build and publish Docker images to GitHub Container Registry on tag pushes, including steps for authentication, metadata extraction, and multi-platform builds.

**Dockerfile Improvements:**

* Installed additional packages (`i2c-tools` and `udev`) in both build and runtime stages to support I2C device management and user-space device handling. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L4-R5) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L17-R30)
* Added `udev` rules and module loading configuration: created a custom udev rule for I2C device permissions and ensured the `i2c-dev` kernel module is loaded at startup, improving hardware access for the `openlinkhub` user.
* Copied a new udev rules file (`99-openlinkhub.rules`) into the image to further customize device handling.