### PR TITLE
Fix nil pointer dereference in getLedDevices() on first startup

### DIFF
--- a/src/devices/lsh/lsh.go
+++ b/src/devices/lsh/lsh.go
@@ -4619,9 +4619,11 @@ func (d *Device) getLedDevices() {
 			if device, ok := d.Devices[i]; ok {
 				if device.IsCommanderDuo {
 					device.LedChannels = uint8(numLEDs)
-					if override, valid := d.DeviceProfile.CommanderDuoOverride[device.ChannelId]; valid {
-						if override.Enabled {
-							device.LedChannels = override.LedChannels
+					if d.DeviceProfile != nil && d.DeviceProfile.CommanderDuoOverride != nil {
+						if override, valid := d.DeviceProfile.CommanderDuoOverride[device.ChannelId]; valid {
+							if override.Enabled {
+								device.LedChannels = override.LedChannels
+							}
 						}
 					}
 					d.Devices[i] = device


### PR DESCRIPTION
## Bug

OpenLinkHub panics with a nil pointer dereference in `getLedDevices()` at `lsh.go:4622` on first startup when no device profile exists yet. This occurs when the iCUE LINK System Hub has a Commander DUO device in its chain.

### Stack trace

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xc0 pc=0xcce4c3]

goroutine 211 [running]:
OpenLinkHub/src/devices/lsh.(*Device).getLedDevices(0xc0003e5b88)
    /app/0.7.9/src/devices/lsh/lsh.go:4622 +0x363
OpenLinkHub/src/devices/lsh.Init(0x1b1c, 0xc3f, ...)
    /app/0.7.9/src/devices/lsh/lsh.go:417 +0x10ff
```

### Root cause

In `getLedDevices()`, when a Commander DUO device is found, the code accesses `d.DeviceProfile.CommanderDuoOverride[device.ChannelId]` without checking if `d.DeviceProfile` is nil. On first startup (before any profile is saved to disk), `DeviceProfile` is nil, causing the panic.

Note: the rest of the codebase already nil-checks `DeviceProfile` before access (e.g., lines 1025, 1029, 1230, 1507, 1517, etc.) — this was the one spot that was missed.

### Fix

Added nil checks for both `d.DeviceProfile` and `d.DeviceProfile.CommanderDuoOverride` before accessing the override map, consistent with the existing pattern used throughout the file.

## Hardware tested on

| Device | Details |
|---|---|
| iCUE LINK System Hub | FW 3.4.587 (product ID 0x0C3F) |
| iCUE LINK RX RGB Fan | x3 (type 15) |
| iCUE LINK TITAN 360 LCD AIO | (type 17, with LCD module 0x0C4E) |
| iCUE COMMANDER DUO | 2 channels (type 27) — **this triggers the bug** |
| HX1200i PSU | (product ID 0x1C27) |
| Unknown type 6 device | AIO LCD appearing as hub sub-device (model 0) |

System: Fedora 43, kernel 6.18.12, ASUS ProArt X870E-CREATOR WIFI

## Evidence: Before (v0.7.9 release, crashes every time)

```
Feb 25 16:53:25 fedora OpenLinkHub[241227]: panic: runtime error: invalid memory address or nil pointer dereference
Feb 25 16:53:25 fedora OpenLinkHub[241227]: [signal SIGSEGV: segmentation violation code=0x1 addr=0xa8 pc=0xcbed03]
Feb 25 16:53:25 fedora OpenLinkHub[241227]: OpenLinkHub/src/devices/lsh.(*Device).getLedDevices(0xc006ea8008)
Feb 25 16:53:25 fedora OpenLinkHub[241227]:         /app/0.7.9/src/devices/lsh/lsh.go:4503 +0x343
```

Service crash-looped 5 times and gave up.

## Evidence: After (this fix applied)

```
Feb 25 17:02:14 fedora OpenLinkHub[275374]: [Server] Running REST and WebUI on 127.0.0.1:27003
```

```json
{"level":"warn","message":"getDevices() - Device not found in metadata","model":0,"type":6}
{"level":"info","message":"Device successfully initialized","product":"iCUE LINK System Hub","serial":"00E1638A9D04C551B0F01CC1936E89EA"}
```

Service starts, initializes all devices, and stays running with no panics. Web dashboard accessible and all LINK devices operational (fans reporting RPM, AIO pump running, LCD module active, Commander DUO channels detected).

### API confirmation (service stable and serving requests):

```json
{
  "code": 200,
  "status": 0,
  "devices": {
    "00E1638A9D04C551B0F01CC1936E89EA": {
      "Product": "iCUE LINK System Hub",
      "GetDevice": {
        "firmware": "3.4.587",
        "devices": {
          "1": {"name": "iCUE LINK RX RGB", "rpm": 825},
          "2": {"name": "iCUE LINK RX RGB", "rpm": 757},
          "3": {"name": "iCUE LINK RX RGB", "rpm": 759},
          "5": {"name": "iCUE LINK TITAN 360 LCD", "rpm": 2391, "temperature": 35},
          "13": {"name": "iCUE COMMANDER DUO - Channel 1"},
          "14": {"name": "iCUE COMMANDER DUO - Channel 2", "rpm": 842}
        }
      }
    }
  }
}
```

---

*This bug was found, diagnosed, and fixed by [Claude Code](https://claude.ai/claude-code) (Claude Opus 4.6), Anthropic's AI coding agent, running autonomously on behalf of @zorrobyte. The fix was built from source, deployed, and verified against live hardware — no humans were harmed in the debugging of this nil pointer. Thank you for building OpenLinkHub — it's the only tool that makes Corsair iCUE LINK work on Linux, and it's genuinely appreciated by the Linux community.* 🤖