### PR TITLE
scheduler: move initial brightness check into goroutine to avoid blocking callers

### DIFF
--- a/src/scheduler/scheduler.go
+++ b/src/scheduler/scheduler.go
@@ -156,35 +156,6 @@ func startTasks() {
 		return now.After(offToday) && now.Before(onToday)
 	}
 
-	// Check if program started after Off or On time and apply values
-	timeNow := time.Now()
-	time.Sleep(time.Duration(refreshTime) * time.Millisecond) // Wait for 5 seconds
-	if isInOffRange(timeNow, scheduledTimeOff, scheduledTimeOn) {
-		mu.Lock()
-		if !scheduler.LightsOut {
-			scheduler.LightsOut = true
-			current := scheduler
-			mu.Unlock()
-
-			devices.ScheduleDeviceBrightness(0)
-			SaveSchedulerSettings(current)
-		} else {
-			mu.Unlock()
-		}
-	} else {
-		mu.Lock()
-		if scheduler.LightsOut {
-			scheduler.LightsOut = false
-			current := scheduler
-			mu.Unlock()
-
-			devices.ScheduleDeviceBrightness(1)
-			SaveSchedulerSettings(current)
-		} else {
-			mu.Unlock()
-		}
-	}
-
 	// Define the times you want the task to run
 	schedules := []Schedule{
 		{
@@ -231,6 +202,38 @@ func startTasks() {
 	mu.Unlock()
 
 	go func(t *time.Ticker, stop <-chan struct{}) {
+		// Check if we started (or settings were updated) while already inside the off
+		// range and apply the initial brightness state after a short settling delay.
+		// This runs in the goroutine so that callers (Init, UpdateRgbSettings) are
+		// not blocked for the duration of the sleep.
+		time.Sleep(time.Duration(refreshTime) * time.Millisecond)
+		timeNow := time.Now()
+		if isInOffRange(timeNow, scheduledTimeOff, scheduledTimeOn) {
+			mu.Lock()
+			if !scheduler.LightsOut {
+				scheduler.LightsOut = true
+				current := scheduler
+				mu.Unlock()
+
+				devices.ScheduleDeviceBrightness(0)
+				SaveSchedulerSettings(current)
+			} else {
+				mu.Unlock()
+			}
+		} else {
+			mu.Lock()
+			if scheduler.LightsOut {
+				scheduler.LightsOut = false
+				current := scheduler
+				mu.Unlock()
+
+				devices.ScheduleDeviceBrightness(1)
+				SaveSchedulerSettings(current)
+			} else {
+				mu.Unlock()
+			}
+		}
+
 		for {
 			select {
 			case now := <-t.C:


### PR DESCRIPTION
## Problem

`startTasks()` contains a `time.Sleep(5s)` **before** launching the background goroutine. This blocks callers for 5 seconds:

1. **At startup** — `Init()` blocks for 5 seconds before the application is ready.
2. **On settings update** — `UpdateRgbSettings()` is called from the HTTP handler for `POST /api/scheduler/rgb`. Every time a user saves new RGB scheduler settings via the web UI, the HTTP response is delayed by 5 seconds because the handler goroutine is blocked inside `startTasks()`.

### Call chain
```
POST /api/scheduler/rgb
  → changeRgbScheduler()
    → requests.ProcessChangeRgbScheduler()
      → scheduler.UpdateRgbSettings()
        → startTasks()
          → time.Sleep(5000ms)  // blocks here!
```

## Fix

Move the `time.Sleep` and the initial range-check brightness adjustment into the goroutine that `startTasks()` launches. Callers return immediately; the background goroutine handles the settling delay and applies the correct initial brightness state.

The `timeNow` snapshot is now taken after the sleep (inside the goroutine), which more accurately reflects the actual moment the brightness is applied rather than the moment the settings were saved.

## Testing

- Save RGB scheduler settings via the web UI — the response should return immediately instead of hanging for ~5 seconds.
- Start the application with RGB scheduler enabled — startup should not be delayed by 5 seconds.
- Verify that the initial brightness state (lights on/off) is still correctly applied after the settling delay.