### PR TITLE
Replace sudo commands with run0 for user space install

### DIFF
--- a/install-user-space.sh
+++ b/install-user-space.sh
@@ -67,9 +67,17 @@ fi
 echo "Preparing permission file..."
 sed -i -e "s/$SEARCH_FOR_GROUP/$REPLACE_WITH/g" "$PERMISSION_FILE"
 
+# Check if sudo is available
+if command -v sudo &>/dev/null; then
+    PRIVILEGED_CMD="sudo"
+else
+    echo "sudo not found. Falling back to run0"
+    PRIVILEGED_CMD="run0 -i"
+fi
+
 echo "Running privileged operations in one batch..."
 
-run0 -i bash <<EOF
+$PRIVILEGED_CMD bash <<EOF
 set -e
 
 # Create group if needed

--- a/install-user-space.sh
+++ b/install-user-space.sh
@@ -29,7 +29,7 @@ else
     # Loop through system GIDs to find a free one
     for gid in $(seq 999 -1 900); do
         if ! getent group "$gid" >/dev/null; then
-            sudo groupadd -g "$gid" "$SEARCH_FOR"
+            run0 -i groupadd -g "$gid" "$SEARCH_FOR"
             echo "Created group '$SEARCH_FOR' with GID $gid"
             break
         fi
@@ -39,7 +39,7 @@ fi
 if id -nG "$USER_TO_CHECK" | grep -qw "$SEARCH_FOR"; then
     echo "$USER_TO_CHECK is already in $SEARCH_FOR"
 else
-    sudo usermod -aG "$SEARCH_FOR" "$USER_TO_CHECK"
+    run0 -i usermod -aG "$SEARCH_FOR" "$USER_TO_CHECK"
     echo "Added $USER_TO_CHECK to $SEARCH_FOR"
 fi
 
@@ -73,12 +73,12 @@ fi
 
 echo "Copy device permission file $PERMISSION_FILE to $PERMISSION_DIR"
 sed -i -e "s/$SEARCH_FOR_GROUP/$REPLACE_WITH/g" $PERMISSION_FILE
-sudo cp "$CURRENT_DIR/$PERMISSION_FILE" $PERMISSION_DIR
-sudo chmod -x $PERMISSION_DIR
+run0 -i cp "$CURRENT_DIR/$PERMISSION_FILE" $PERMISSION_DIR
+run0 -i chmod -x $PERMISSION_DIR
 
 echo "Reloading permissions..."
-sudo udevadm control --reload-rules
-sudo udevadm trigger
+run0 -i udevadm control --reload-rules
+run0 -i udevadm trigger
 
 echo "Setting folder permissions..."
 chmod -R 755 "$CURRENT_DIR"

--- a/install-user-space.sh
+++ b/install-user-space.sh
@@ -10,7 +10,7 @@ USER_TO_CHECK=$USER
 SEARCH_FOR_GROUP='OWNER="openlinkhub"'
 REPLACE_WITH='GROUP="openlinkhub"'
 
-if [ ! -f $PRODUCT ]; then
+if [ ! -f "$PRODUCT" ]; then
   echo "No binary file. Exit"
   exit 0
 fi
@@ -23,30 +23,23 @@ else
     exit 0
 fi
 
+GROUP_EXISTS=false
 if getent group "$SEARCH_FOR" >/dev/null; then
     echo "Group '$SEARCH_FOR' already exists, skipping creation."
-else
-    # Loop through system GIDs to find a free one
-    for gid in $(seq 999 -1 900); do
-        if ! getent group "$gid" >/dev/null; then
-            run0 -i groupadd -g "$gid" "$SEARCH_FOR"
-            echo "Created group '$SEARCH_FOR' with GID $gid"
-            break
-        fi
-    done
+    GROUP_EXISTS=true
 fi
 
+USER_IN_GROUP=false
 if id -nG "$USER_TO_CHECK" | grep -qw "$SEARCH_FOR"; then
     echo "$USER_TO_CHECK is already in $SEARCH_FOR"
-else
-    run0 -i usermod -aG "$SEARCH_FOR" "$USER_TO_CHECK"
-    echo "Added $USER_TO_CHECK to $SEARCH_FOR"
+    USER_IN_GROUP=true
 fi
 
 SYSTEMD_FILE="/home/$USER_TO_CHECK/.config/systemd/user/OpenLinkHub.service"
 
 echo "Creating User systemd file..."
-mkdir -p ~/.config/systemd/user
+mkdir -p "/home/$USER_TO_CHECK/.config/systemd/user"
+
 cat > "$SYSTEMD_FILE" <<- EOM
 [Unit]
 Description=Open source interface for iCUE LINK System Hub, Corsair AIOs and Hubs
@@ -66,22 +59,48 @@ WantedBy=default.target
 EOM
 
 if [ -f "$SYSTEMD_FILE" ]; then
-  echo "User systemd file: $SYSTEMD_FILE created"
+  echo "User systemd file created"
   systemctl --user daemon-reload
-  systemctl --user enable $PRODUCT
+  systemctl --user enable "$PRODUCT"
 fi
 
-echo "Copy device permission file $PERMISSION_FILE to $PERMISSION_DIR"
-sed -i -e "s/$SEARCH_FOR_GROUP/$REPLACE_WITH/g" $PERMISSION_FILE
-run0 -i cp "$CURRENT_DIR/$PERMISSION_FILE" $PERMISSION_DIR
-run0 -i chmod -x $PERMISSION_DIR
+echo "Preparing permission file..."
+sed -i -e "s/$SEARCH_FOR_GROUP/$REPLACE_WITH/g" "$PERMISSION_FILE"
 
-echo "Reloading permissions..."
-run0 -i udevadm control --reload-rules
-run0 -i udevadm trigger
+echo "Running privileged operations in one batch..."
 
-echo "Setting folder permissions..."
-chmod -R 755 "$CURRENT_DIR"
+run0 -i bash <<EOF
+set -e
+
+# Create group if needed
+if [ "$GROUP_EXISTS" = false ]; then
+    for gid in \$(seq 999 -1 900); do
+        if ! getent group "\$gid" >/dev/null; then
+            groupadd -g "\$gid" "$SEARCH_FOR"
+            echo "Created group '$SEARCH_FOR' with GID \$gid"
+            break
+        fi
+    done
+fi
+
+# Add user to group if needed
+if [ "$USER_IN_GROUP" = false ]; then
+    usermod -aG "$SEARCH_FOR" "$USER_TO_CHECK"
+    echo "Added $USER_TO_CHECK to $SEARCH_FOR"
+fi
+
+# Copy udev rule
+cp "$CURRENT_DIR/$PERMISSION_FILE" "$PERMISSION_DIR"
+chmod -x "$PERMISSION_DIR"
+
+# Reload udev rules
+udevadm control --reload-rules
+udevadm trigger
+
+# Fix ownership and permissions
 chown -R "$USER_TO_CHECK":"$USER_TO_CHECK" "$CURRENT_DIR"
+chmod -R 755 "$CURRENT_DIR"
 
-echo "Done. Reboot your system with systemctl reboot"
+EOF
+
+echo "Done. Reboot your system with: systemctl reboot"


### PR DESCRIPTION
**Summary:**

This PR updates install-user-space.sh by replacing all instances of sudo with run0 -i.

**Motivation:**

Some distributions (e.g., secureblue and other minimal or security-focused systems) do not include or rely on sudo. This change improves compatibility by using run0, which provides equivalent privilege escalation in these environments.

**Impact:**

- Improves support for distributions without sudo
- Maintains the intended behavior of executing commands with elevated privileges
- No functional changes expected on systems where run0 is available

**Possible Issues:**

- Systems without run0 will no longer be able to execute the script without modification
- run0 was introduced with systemd 256 (released over two years ago), so this should not be an issue for most modern distributions, including stable distributions like Debian
- Unlike sudo, credential caching behavior may differ, and users may be prompted for their password multiple times during script execution

