### PR TITLE
feat(cc): allow CustomLEDs override of auto-detected LED type for daisy-chain support

### DIFF
--- a/src/devices/cc/cc.go
+++ b/src/devices/cc/cc.go
@@ -304,6 +304,9 @@ type Device struct {
 	RGBModes           []string
 	queue              chan []byte
 	instance           *common.Device
+	// initSpeedChannels captures the speed-channel count observed in
+	// getDevices() at startup. Used to clamp later HID reads under load.
+	initSpeedChannels int
 }
 
 /*
@@ -1495,6 +1498,7 @@ func (d *Device) getDevices() int {
 	// Fans
 	response := d.read(modeGetFans, "getDevices")
 	amount := d.getChannelAmount(response)
+	d.initSpeedChannels = amount
 	if d.Debug {
 		logger.Log(logger.Fields{"serial": d.Serial, "data": fmt.Sprintf("%2x", response), "amount": amount, "device": d.Product}).Info("getDevices() - Speed")
 	}
@@ -2044,6 +2048,28 @@ func (d *Device) getDeviceData() {
 	amount := d.getChannelAmount(channels)
 	sensorData := response[6:]
 
+	// Defensive clamp: HID timing skew under high system load can corrupt
+	// channels[5], yielding bogus channel counts. Clamp against:
+	//  1. the channel count we observed at init (initSpeedChannels) — the
+	//     authoritative value for this hardware
+	//  2. the actual buffer sizes — final guard against any slice panic
+	// Without (1), m walks past real channels, breaking probe temperature
+	// updates in the temperature loop below. Without (2), short reads panic.
+	if d.initSpeedChannels > 0 && amount > d.initSpeedChannels {
+		amount = d.initSpeedChannels
+	}
+	if max := len(sensorData) / 2; amount > max {
+		amount = max
+	}
+	if len(channels) < 6 {
+		amount = 0
+	} else if max := len(channels) - 6; amount > max {
+		amount = max
+	}
+	if amount < 0 {
+		amount = 0
+	}
+
 	if d.Debug {
 		logger.Log(logger.Fields{"serial": d.Serial, "data": fmt.Sprintf("%2x", response), "amount": amount, "device": d.Product}).Info("getDeviceData() - Speed")
 	}
@@ -2065,6 +2091,14 @@ func (d *Device) getDeviceData() {
 		m++
 	}
 
+	// If the speed read was short and we clamped early, push m to its
+	// post-init position so the temperature probe slots line up correctly
+	// in the temperature loop below. Without this, probe temperatures get
+	// written into fan device entries.
+	if d.initSpeedChannels > 0 && m < d.initSpeedChannels {
+		m = d.initSpeedChannels
+	}
+
 	// Temperature
 	response = d.read(modeGetTemperatures, "getDeviceData")
 	if response == nil {
@@ -2073,6 +2107,13 @@ func (d *Device) getDeviceData() {
 
 	amount = d.getChannelAmount(response)
 	sensorData = response[6:]
+	// Same defensive clamp as the speed loop above. Stride here is 3.
+	if max := len(sensorData) / 3; amount > max {
+		amount = max
+	}
+	if amount < 0 {
+		amount = 0
+	}
 	for i, s := 0, 0; i < amount; i, s = i+1, s+3 {
 		if d.Exit {
 			break

--- a/src/devices/cc/cc.go
+++ b/src/devices/cc/cc.go
@@ -169,6 +169,52 @@ var (
 			Total:   8,
 			Command: 05,
 		},
+		// Daisy-chain entries: a single CC port can drive multiple
+		// fans via a passive RGB splitter / Y-cable. Auto-detection only
+		// sees the first fan; user picks the matching chain entry via
+		// /api/argb to override the per-port LED count.
+		{
+			Index:   7,
+			Name:    "LL RGB Fan x2 (Chain)",
+			Total:   32,
+			Command: 02,
+		},
+		{
+			Index:   8,
+			Name:    "LL RGB Fan x3 (Chain)",
+			Total:   48,
+			Command: 02,
+		},
+		{
+			Index:   9,
+			Name:    "LL RGB Fan x4 (Chain)",
+			Total:   64,
+			Command: 02,
+		},
+		{
+			Index:   10,
+			Name:    "QL RGB Fan x2 (Chain)",
+			Total:   68,
+			Command: 06,
+		},
+		{
+			Index:   11,
+			Name:    "QL RGB Fan x3 (Chain)",
+			Total:   102,
+			Command: 06,
+		},
+		{
+			Index:   12,
+			Name:    "HD RGB Fan x2 (Chain)",
+			Total:   24,
+			Command: 04,
+		},
+		{
+			Index:   13,
+			Name:    "HD RGB Fan x3 (Chain)",
+			Total:   36,
+			Command: 04,
+		},
 	}
 )
 
@@ -923,6 +969,25 @@ func (d *Device) getLedDevices() {
 			d.internalLedDevices[i] = leds
 			d.FreeLedPorts[i] = fmt.Sprintf("RGB Port %d", i)
 		}
+
+		// User-configured override (CustomLEDs map, set via /api/argb).
+		// Auto-detection cannot see daisy-chain depth: a port with 3
+		// LL120s daisy-chained still reports as one 16-LED device.
+		// When the user explicitly picks a chain or non-default device
+		// type, honor it over the auto-detected value.
+		if d.DeviceProfile != nil {
+			if deviceType, ok := d.DeviceProfile.CustomLEDs[i]; ok && deviceType > 0 {
+				if override := d.getExternalLedDevice(deviceType); override != nil {
+					existing := d.internalLedDevices[i]
+					existing.Total = uint8(override.Total)
+					existing.Command = override.Command
+					existing.Name = override.Name
+					d.internalLedDevices[i] = existing
+					delete(d.FreeLedPorts, i)
+				}
+			}
+		}
+
 		m += 4
 	}
 }

--- a/src/devices/cc/cc.go
+++ b/src/devices/cc/cc.go
@@ -2244,6 +2244,12 @@ func (d *Device) UpdateRGBDeviceLabel(channelId int, label string) uint8 {
 // UpdateDeviceLcd will update device LCD
 func (d *Device) UpdateDeviceLcd(_ int, mode uint8) uint8 {
 	if d.HasLCD {
+		// Serialize all LCD state mutations. Concurrent HTTP requests
+		// (e.g. cron + UI) previously raced into close(d.lcdRefreshChan)
+		// twice and panicked the HTTP handler.
+		d.mutexLcd.Lock()
+		defer d.mutexLcd.Unlock()
+
 		value := d.DeviceProfile.LCDMode
 		if mode == lcd.DisplayImage {
 			if len(lcd.GetLcdImages()) == 0 {
@@ -2262,12 +2268,17 @@ func (d *Device) UpdateDeviceLcd(_ int, mode uint8) uint8 {
 				d.LCDImage = &lcdImage
 			}
 
-			// Stop lcd timer and switch to animation loop
+			// Stop lcd timer and switch to animation loop. Nil-out the
+			// channel after close so a subsequent call does not double-close
+			// (which would panic the HTTP handler).
 			if d.lcdRefreshChan != nil {
 				close(d.lcdRefreshChan)
+				d.lcdRefreshChan = nil
 			}
 
-			d.lcdTimer.Stop()
+			if d.lcdTimer != nil {
+				d.lcdTimer.Stop()
+			}
 			d.setupLCDImage()
 		} else {
 			// Reset if old value was Animation and new mode is not


### PR DESCRIPTION
## Problem

Commander Core auto-detection in `getLedDevices()` (cc.go:842) trusts the firmware-reported LED count per port. That count only reflects the **first fan** on a daisy-chain port — the chain depth is invisible to the firmware enumeration. So a single CC port driving e.g. 3× LL120 fans via a passive splitter gets enumerated as a single 16-LED LL120, the LED frame is sized for 16 LEDs, only fan 1 in the chain ever receives data, and fans 2/3 fall back to the on-fan firmware-default animation.

Visible symptom: 1 fan in the chain shows the requested colour, the others cycle a default rainbow / red glow.

## Approach

Reuse the existing `CustomLEDs` map + `/api/argb` endpoint. Currently `CustomLEDs` is only consulted at `resetLEDPorts()` when auto-detection found nothing on a port (line 3058). Auto-detected ports cannot be overridden, even if the user knows their topology better than the firmware.

This PR:

1. Adds 7 new `externalLedDevices` entries for common daisy-chain combinations:
   * LL120 x2/x3/x4 (32 / 48 / 64 LEDs, command 0x02)
   * QL120 x2/x3 (68 / 102 LEDs, command 0x06)
   * HD120 x2/x3 (24 / 36 LEDs, command 0x04)
2. After both branches of the per-port loop in `getLedDevices()`, applies a `CustomLEDs[port]` override when the user has explicitly set one. Defaults preserved (`CustomLEDs[port] == 0` → no change → existing auto-detect behaviour).

The override path uses the existing `/api/argb` endpoint (`ProcessARGBDevice`, requests.go:3017), so no API additions are needed.

## Backward compat

* Default behaviour unchanged: users without an explicit `/api/argb` call get the same auto-detected internal device they always did.
* Only triggers when a user has explicitly picked a chain entry via the UI or the existing API.
* No change to `resetLEDPorts()`, no change to LED buffer assembly, no change to mutex behaviour.

## Verification

* Hand-traced through `getLedDevices()` → `getRgbDevices()` → `setDeviceColor()` → `writeColor()`: `d.RgbDevices[port].LedChannels` follows the overridden `internalLedDevices[port].Total`, so the multi-chunk LED frame is sized correctly for the chain.
* Verified live against a 6-fan setup on a Crystal 680X case + H100i Elite LCD pump:
  * Port 1: 1× LL120 (16 LEDs, no override)
  * Port 2: 3× LL120 chain (override device-type 8 → 48 LEDs)
  * Port 3: 2× LL120 chain (override device-type 7 → 32 LEDs)
* All fans + pump LCD ring respond to a static colour change after the override is set, with a single LED frame of \`24 + 16 + 48 + 32 + 16 + 16 + 16 = 168\` LEDs (504 bytes).
* `go vet ./src/devices/cc` passes.

## Notes

Builds on top of #415 (cc.go bounds-clamp + LCD mutex fix). Does not depend on it but the same branch tip is convenient.

## Usage example

After this PR, the user enables daisy-chain support per port via the existing API:

\`\`\`bash
# Port 2 has 3× LL120 daisy-chained:
curl -X POST http://127.0.0.1:27003/api/argb \\
     -d '{\"deviceId\":\"<serial>\",\"portId\":2,\"deviceType\":8}'
# Port 3 has 2× LL120 daisy-chained:
curl -X POST http://127.0.0.1:27003/api/argb \\
     -d '{\"deviceId\":\"<serial>\",\"portId\":3,\"deviceType\":7}'
\`\`\`

The chain entries also appear in any UI listing `externalLedDevices` so the dropdown gives a friendly name.