### PR TITLE
feat: add French (AZERTY) keyboard layout for K70 RGB MK2

### DIFF
--- a/database/keyboard/k70mk2-fr.json
+++ b/database/keyboard/k70mk2-fr.json
@@ -1,2785 +1,1951 @@
 {
-"device": "K70 MK2",
-"fontSize": 14,
-"key": "k70mk2-default",
-"layout": "FR",
-"row": {
-"0": {
-"keys": {
-"1": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"height": 40,
-"keyEmpty": [
-"keyboard-key-empty",
-"keyboard-key-empty",
-"keyboard-key-empty"
-],
-"keyName": "PF",
-"left": 0,
-"onlyColor": true,
-"packetIndex": [
-125
-],
-"top": 0,
-"width": 65
-},
-"2": {
-"actionType": 11,
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"customKeyData": 193,
-"default": true,
-"height": 70,
-"keyData": [
-134,
-71
-],
-"keyHash": [
-"2361183241434822606848"
-],
-"keyName": "BTS",
-"left": 15,
-"noColor": false,
-"onlyColor": true,
-"packetIndex": [
-137
-],
-"top": 0,
-"width": 65
-},
-"3": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"isLock": true,
-"keyData": [
-178,
-96
-],
-"keyHash": [
-"79228162514264337593543950336"
-],
-"keyName": "LOCK",
-"left": 15,
-"onlyColor": true,
-"packetIndex": [
-8
-],
-"top": 0,
-"width": 65
-},
-"4": {
-"color": {
-"blue": 0,
-"green": 255,
-"red": 255
-},
-"height": 40,
-"keyEmpty": [
-"keyboard-key-empty",
-"keyboard-key-empty",
-"keyboard-key-empty"
-],
-"keyName": "LOGO",
-"keySpace": "keyboard-key wide3",
-"left": 400,
-"onlyColor": true,
-"packetIndex": [
-47
-],
-"top": 0,
-"width": 202
-},
-"5": {
-"color": {
-"blue": 0,
-"green": 255,
-"red": 255
-},
-"height": 40,
-"keyName": "LOGO",
-"keySpace": "keyboard-key wide3",
-"left": 0,
-"onlyColor": true,
-"packetIndex": [
-59
-],
-"top": 0,
-"width": 202
-},
-"6": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 40,
-"keyData": [
-180,
-97
-],
-"keyEmpty": [
-"keyboard-key-empty",
-"keyboard-key-empty",
-"keyboard-key-empty",
-"keyboard-key-empty",
-"keyboard-key-empty",
-"keyboard-key-empty"
-],
-"keyName": "MUTE",
-"left": 436,
-"packetIndex": [
-20
-],
-"top": 0,
-"width": 65
-},
-"7": {
-"default": true,
-"height": 70,
-"keyData": [
-236,
-130
-],
-"keyHash": [
-"1361129467683753853853498429727072845824"
-],
-"keyName": "W +",
-"left": 15,
-"noColor": true,
-"top": 0,
-"width": 65
-},
-"8": {
-"default": true,
-"height": 70,
-"keyData": [
-238,
-131
-],
-"keyHash": [
-"2722258935367507707706996859454145691648"
-],
-"keyName": "W -",
-"left": 15,
-"noColor": true,
-"top": 0,
-"width": 65
-}
-}
-},
-"1": {
-"keys": {
-"27": {
-"color": {
-"blue": 0,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-0,
-0
-],
-"keyHash": [
-"1"
-],
-"keyName": "ESC",
-"left": 15,
-"packetIndex": [
-0
-],
-"top": 0,
-"width": 65
-},
-"28": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-2,
-1
-],
-"keyEmpty": [
-"keyboard-key-empty"
-],
-"keyHash": [
-"2"
-],
-"keyName": "F1",
-"left": 95,
-"packetIndex": [
-12
-],
-"top": 0,
-"width": 65
-},
-"29": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-4,
-2
-],
-"keyHash": [
-"4"
-],
-"keyName": "F2",
-"left": 15,
-"packetIndex": [
-24
-],
-"top": 0,
-"width": 65
-},
-"30": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-6,
-3
-],
-"keyHash": [
-"8"
-],
-"keyName": "F3",
-"left": 15,
-"packetIndex": [
-36
-],
-"top": 0,
-"width": 65
-},
-"31": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-8,
-4
-],
-"keyHash": [
-"16"
-],
-"keyName": "F4",
-"left": 15,
-"packetIndex": [
-48
-],
-"top": 0,
-"width": 65
-},
-"32": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-10,
-5
-],
-"keyEmpty": [
-"keyboard-key-empty"
-],
-"keyHash": [
-"32"
-],
-"keyName": "F5",
-"left": 55,
-"packetIndex": [
-60
-],
-"top": 0,
-"width": 65
-},
-"33": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-12,
-6
-],
-"keyHash": [
-"64"
-],
-"keyName": "F6",
-"left": 15,
-"packetIndex": [
-72
-],
-"top": 0,
-"width": 65
-},
-"34": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-14,
-7
-],
-"keyHash": [
-"128"
-],
-"keyName": "F7",
-"left": 15,
-"packetIndex": [
-84
-],
-"top": 0,
-"width": 65
-},
-"35": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-16,
-8
-],
-"keyHash": [
-"256"
-],
-"keyName": "F8",
-"left": 15,
-"packetIndex": [
-96
-],
-"top": 0,
-"width": 65
-},
-"36": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-18,
-9
-],
-"keyEmpty": [
-"keyboard-key-empty"
-],
-"keyHash": [
-"512"
-],
-"keyName": "F9",
-"left": 60,
-"packetIndex": [
-108
-],
-"top": 0,
-"width": 65
-},
-"37": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-20,
-10
-],
-"keyHash": [
-"1024"
-],
-"keyName": "F10",
-"left": 15,
-"packetIndex": [
-120
-],
-"top": 0,
-"width": 65
-},
-"38": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-22,
-11
-],
-"keyHash": [
-"2048"
-],
-"keyName": "F11",
-"left": 15,
-"packetIndex": [
-132
-],
-"top": 0,
-"width": 65
-},
-"39": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-136,
-72
-],
-"keyHash": [
-"4722366482869645213696"
-],
-"keyName": "F12",
-"left": 15,
-"packetIndex": [
-6
-],
-"top": 0,
-"width": 65
-},
-"40": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-138,
-73
-],
-"keyEmpty": [
-"keyboard-key-empty"
-],
-"keyHash": [
-"9444732965739290427392"
-],
-"keyName": "PrtSc",
-"left": 25,
-"packetIndex": [
-18
-],
-"top": 0,
-"width": 65
-},
-"41": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-140,
-74
-],
-"keyHash": [
-"18889465931478580854784"
-],
-"keyName": "ScrLk",
-"left": 15,
-"packetIndex": [
-30
-],
-"top": 0,
-"width": 65
-},
-"42": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-142,
-75
-],
-"keyHash": [
-"37778931862957161709568"
-],
-"keyName": "Pause",
-"left": 15,
-"packetIndex": [
-42
-],
-"top": 0,
-"width": 65
-},
-"43": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-182,
-98
-],
-"keyEmpty": [
-"keyboard-key-empty"
-],
-"keyHash": [
-"316912650057057350374175801344"
-],
-"keyName": "Stop",
-"left": 15,
-"packetIndex": [
-32
-],
-"top": 0,
-"width": 65
-},
-"44": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-184,
-99
-],
-"keyHash": [
-"633825300114114700748351602688"
-],
-"keyName": "Prev",
-"left": 15,
-"packetIndex": [
-44
-],
-"top": 0,
-"width": 65
-},
-"45": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-186,
-100
-],
-"keyHash": [
-"1267650600228229401496703205376"
-],
-"keyName": "Play",
-"left": 15,
-"packetIndex": [
-56
-],
-"top": 0,
-"width": 65
-},
-"46": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-188,
-101
-],
-"keyHash": [
-"2535301200456458802993406410752"
-],
-"keyName": "Next",
-"left": 15,
-"packetIndex": [
-68
-],
-"top": 0,
-"width": 65
-}
-}
-},
-"2": {
-"keys": {
-"48": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-24,
-12
-],
-"keyHash": [
-"4096"
-],
-"keyName": "² ³",
-"left": 15,
-"packetIndex": [
-1
-],
-"top": 15,
-"width": 65
-},
-"49": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-26,
-13
-],
-"keyHash": [
-"8192"
-],
-"keyName": "& 1",
-"left": 15,
-"packetIndex": [
-13
-],
-"top": 15,
-"width": 65
-},
-"50": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-28,
-14
-],
-"keyHash": [
-"16384"
-],
-"keyName": "é 2",
-"left": 15,
-"packetIndex": [
-25
-],
-"top": 15,
-"width": 65
-},
-"51": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-30,
-15
-],
-"keyHash": [
-"32768"
-],
-"keyName": "\" 3",
-"left": 15,
-"packetIndex": [
-37
-],
-"top": 15,
-"width": 65
-},
-"52": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-32,
-16
-],
-"keyHash": [
-"65536"
-],
-"keyName": "' 4",
-"left": 15,
-"packetIndex": [
-49
-],
-"top": 15,
-"width": 65
-},
-"53": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-34,
-17
-],
-"keyHash": [
-"131072"
-],
-"keyName": "( 5",
-"left": 15,
-"packetIndex": [
-61
-],
-"top": 15,
-"width": 65
-},
-"54": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-36,
-18
-],
-"keyHash": [
-"262144"
-],
-"keyName": "- 6",
-"left": 15,
-"packetIndex": [
-73
-],
-"top": 15,
-"width": 65
-},
-"55": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-38,
-19
-],
-"keyHash": [
-"524288"
-],
-"keyName": "è 7",
-"left": 15,
-"packetIndex": [
-85
-],
-"top": 15,
-"width": 65
-},
-"56": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-40,
-20
-],
-"keyHash": [
-"1048576"
-],
-"keyName": "_ 8",
-"left": 15,
-"packetIndex": [
-97
-],
-"top": 15,
-"width": 65
-},
-"57": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-42,
-21
-],
-"keyHash": [
-"2097152"
-],
-"keyName": "ç 9",
-"left": 15,
-"packetIndex": [
-109
-],
-"top": 15,
-"width": 65
-},
-"58": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-44,
-22
-],
-"keyHash": [
-"4194304"
-],
-"keyName": "à 0",
-"left": 15,
-"packetIndex": [
-121
-],
-"top": 15,
-"width": 65
-},
-"59": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-46,
-23
-],
-"keyHash": [
-"8388608"
-],
-"keyName": ") °",
-"left": 15,
-"packetIndex": [
-133
-],
-"top": 15,
-"width": 65
-},
-"60": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-156,
-84
-],
-"keyHash": [
-"19342813113834066795298816"
-],
-"keyName": "= +",
-"left": 15,
-"packetIndex": [
-7
-],
-"top": 15,
-"width": 65
-},
-"61": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-158,
-86
-],
-"keyHash": [
-"77371252455336267181195264"
-],
-"keyName": "<---",
-"keySpace": "keyboard-key wide3",
-"left": 15,
-"packetIndex": [
-31
-],
-"top": 15,
-"width": 150
-},
-"62": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-144,
-76
-],
-"keyEmpty": [
-"keyboard-key-empty"
-],
-"keyHash": [
-"75557863725914323419136"
-],
-"keyName": "Ins",
-"left": 25,
-"packetIndex": [
-54
-],
-"top": 15,
-"width": 65
-},
-"63": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-146,
-77
-],
-"keyHash": [
-"151115727451828646838272"
-],
-"keyName": "Home",
-"left": 15,
-"packetIndex": [
-66
-],
-"top": 15,
-"width": 65
-},
-"64": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-148,
-78
-],
-"keyHash": [
-"302231454903657293676544"
-],
-"keyName": "PgUp",
-"left": 15,
-"packetIndex": [
-78
-],
-"top": 15,
-"width": 65
-},
-"65": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-190,
-102
-],
-"keyEmpty": [
-"keyboard-key-empty"
-],
-"keyHash": [
-"5070602400912917605986812821504"
-],
-"keyName": "Num",
-"left": 25,
-"packetIndex": [
-80
-],
-"top": 15,
-"width": 65
-},
-"66": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-192,
-103
-],
-"keyHash": [
-"10141204801825835211973625643008"
-],
-"keyName": "/",
-"left": 15,
-"packetIndex": [
-92
-],
-"top": 15,
-"width": 65
-},
-"67": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-194,
-104
-],
-"keyHash": [
-"20282409603651670423947251286016"
-],
-"keyName": "*",
-"left": 15,
-"packetIndex": [
-104
-],
-"top": 15,
-"width": 65
-},
-"68": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-196,
-105
-],
-"keyHash": [
-"40564819207303340847894502572032"
-],
-"keyName": "-",
-"left": 15,
-"packetIndex": [
-116
-],
-"top": 15,
-"width": 65
-}
-}
-},
-"3": {
-"keys": {
-"70": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-48,
-24
-],
-"keyHash": [
-"16777216"
-],
-"keyName": "Tab",
-"keySpace": "keyboard-key wide",
-"left": 15,
-"packetIndex": [
-2
-],
-"top": 15,
-"width": 108
-},
-"71": {
-"color": {
-"blue": 0,
-"green": 0,
-"red": 255
-},
-"default": true,
-"height": 70,
-"keyData": [
-50,
-25
-],
-"keyHash": [
-"33554432"
-],
-"keyName": "A",
-"left": 15,
-"packetIndex": [
-14
-],
-"top": 15,
-"width": 65
-},
-"72": {
-"color": {
-"blue": 0,
-"green": 0,
-"red": 255
-},
-"default": true,
-"height": 70,
-"keyData": [
-52,
-26
-],
-"keyHash": [
-"67108864"
-],
-"keyName": "Z",
-"left": 15,
-"packetIndex": [
-26
-],
-"top": 15,
-"width": 65
-},
-"73": {
-"color": {
-"blue": 0,
-"green": 0,
-"red": 255
-},
-"default": true,
-"height": 70,
-"keyData": [
-54,
-27
-],
-"keyHash": [
-"134217728"
-],
-"keyName": "E",
-"left": 15,
-"packetIndex": [
-38
-],
-"top": 15,
-"width": 65
-},
-"74": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-56,
-28
-],
-"keyHash": [
-"268435456"
-],
-"keyName": "R",
-"left": 15,
-"packetIndex": [
-50
-],
-"top": 15,
-"width": 65
-},
-"75": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-58,
-29
-],
-"keyHash": [
-"536870912"
-],
-"keyName": "T",
-"left": 15,
-"packetIndex": [
-62
-],
-"top": 15,
-"width": 65
-},
-"76": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-60,
-30
-],
-"keyHash": [
-"1073741824"
-],
-"keyName": "Y",
-"left": 15,
-"packetIndex": [
-74
-],
-"top": 15,
-"width": 65
-},
-"77": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-62,
-31
-],
-"keyHash": [
-"2147483648"
-],
-"keyName": "U",
-"left": 15,
-"packetIndex": [
-86
-],
-"top": 15,
-"width": 65
-},
-"78": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-64,
-32
-],
-"keyHash": [
-"4294967296"
-],
-"keyName": "I",
-"left": 15,
-"packetIndex": [
-98
-],
-"top": 15,
-"width": 65
-},
-"79": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-66,
-33
-],
-"keyHash": [
-"8589934592"
-],
-"keyName": "O",
-"left": 15,
-"packetIndex": [
-110
-],
-"top": 15,
-"width": 65
-},
-"80": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-68,
-34
-],
-"keyHash": [
-"17179869184"
-],
-"keyName": "P",
-"left": 15,
-"packetIndex": [
-122
-],
-"top": 15,
-"width": 65
-},
-"81": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-70,
-35
-],
-"keyHash": [
-"34359738368"
-],
-"keyName": "^ ¨",
-"left": 15,
-"packetIndex": [
-134
-],
-"top": 15,
-"width": 65
-},
-"82": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-150,
-79
-],
-"keyHash": [
-"604462909807314587353088"
-],
-"keyName": "$ £",
-"left": 15,
-"packetIndex": [
-90
-],
-"top": 15,
-"width": 65
-},
-"84": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-160,
-87
-],
-"keyEmpty": [
-"keyboard-key-empty",
-"keyboard-key-empty",
-"keyboard-key-empty"
-],
-"keyHash": [
-"154742504910672534362390528"
-],
-"keyName": "Del",
-"left": 25,
-"packetIndex": [
-43
-],
-"top": 15,
-"width": 65
-},
-"85": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-162,
-88
-],
-"keyHash": [
-"309485009821345068724781056"
-],
-"keyName": "End",
-"left": 15,
-"packetIndex": [
-55
-],
-"top": 15,
-"width": 65
-},
-"86": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-164,
-89
-],
-"keyHash": [
-"618970019642690137449562112"
-],
-"keyName": "PgDn",
-"left": 15,
-"packetIndex": [
-67
-],
-"top": 15,
-"width": 65
-},
-"87": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-202,
-108
-],
-"keyEmpty": [
-"keyboard-key-empty"
-],
-"keyHash": [
-"324518553658426726783156020576256"
-],
-"keyName": "7",
-"left": 25,
-"packetIndex": [
-9
-],
-"top": 15,
-"width": 65
-},
-"88": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-204,
-109
-],
-"keyHash": [
-"649037107316853453566312041152512"
-],
-"keyName": "8",
-"left": 15,
-"packetIndex": [
-21
-],
-"top": 15,
-"width": 65
-},
-"89": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-206,
-110
-],
-"keyHash": [
-"1298074214633706907132624082305024"
-],
-"keyName": "9",
-"left": 15,
-"packetIndex": [
-33
-],
-"top": 15,
-"width": 65
-},
-"90": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 155,
-"keyData": [
-198,
-106
-],
-"keyHash": [
-"81129638414606681695789005144064"
-],
-"keyName": "+",
-"keySpace": "keyboard-key-125",
-"left": 15,
-"packetIndex": [
-128
-],
-"top": 15,
-"width": 65
-}
-},
-"top": 65
-},
-"4": {
-"css": "keyboard-row-25",
-"keys": {
-"92": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-72,
-36
-],
-"keyHash": [
-"68719476736"
-],
-"keyName": "CAPS",
-"keySpace": "keyboard-key wide",
-"left": 15,
-"packetIndex": [
-3
-],
-"top": 15,
-"width": 131
-},
-"93": {
-"color": {
-"blue": 0,
-"green": 0,
-"red": 255
-},
-"default": true,
-"height": 70,
-"keyData": [
-74,
-37
-],
-"keyHash": [
-"137438953472"
-],
-"keyName": "Q",
-"left": 15,
-"packetIndex": [
-15
-],
-"top": 15,
-"width": 65
-},
-"94": {
-"color": {
-"blue": 0,
-"green": 0,
-"red": 255
-},
-"default": true,
-"height": 70,
-"keyData": [
-76,
-38
-],
-"keyHash": [
-"274877906944"
-],
-"keyName": "S",
-"left": 15,
-"packetIndex": [
-27
-],
-"top": 15,
-"width": 65
-},
-"95": {
-"color": {
-"blue": 0,
-"green": 0,
-"red": 255
-},
-"default": true,
-"height": 70,
-"keyData": [
-78,
-39
-],
-"keyHash": [
-"549755813888"
-],
-"keyName": "D",
-"left": 15,
-"packetIndex": [
-39
-],
-"top": 15,
-"width": 65
-},
-"96": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-80,
-40
-],
-"keyHash": [
-"1099511627776"
-],
-"keyName": "F",
-"left": 15,
-"packetIndex": [
-51
-],
-"top": 15,
-"width": 65
-},
-"97": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-82,
-41
-],
-"keyHash": [
-"2199023255552"
-],
-"keyName": "G",
-"left": 15,
-"packetIndex": [
-63
-],
-"top": 15,
-"width": 65
-},
-"98": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-84,
-42
-],
-"keyHash": [
-"4398046511104"
-],
-"keyName": "H",
-"left": 15,
-"packetIndex": [
-75
-],
-"top": 15,
-"width": 65
-},
-"99": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-86,
-43
-],
-"keyHash": [
-"8796093022208"
-],
-"keyName": "J",
-"left": 15,
-"packetIndex": [
-87
-],
-"top": 15,
-"width": 65
-},
-"100": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-88,
-44
-],
-"keyHash": [
-"17592186044416"
-],
-"keyName": "K",
-"left": 15,
-"packetIndex": [
-99
-],
-"top": 15,
-"width": 65
-},
-"101": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-90,
-45
-],
-"keyHash": [
-"35184372088832"
-],
-"keyName": "L",
-"left": 15,
-"packetIndex": [
-111
-],
-"top": 15,
-"width": 65
-},
-"102": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-92,
-46
-],
-"keyHash": [
-"70368744177664"
-],
-"keyName": "M",
-"left": 15,
-"packetIndex": [
-123
-],
-"top": 15,
-"width": 65
-},
-"103": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-94,
-47
-],
-"keyHash": [
-"140737488355328"
-],
-"keyName": "ù %",
-"left": 15,
-"packetIndex": [
-135
-],
-"top": 15,
-"width": 65
-},
-"104": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-162,
-81
-],
-"keyHash": [
-"2417851639229258349412352"
-],
-"keyName": "* µ",
-"left": 15,
-"packetIndex": [
-114
-],
-"top": 15,
-"width": 107
-},
-"105": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"css": "enter-custom",
-"default": true,
-"height": 155,
-"keyData": [
-154,
-82
-],
-"keyHash": [
-"4835703278458516698824704"
-],
-"keyName": "Enter",
-"keySpace": "keyboard-key wide",
-"left": 15,
-"packetIndex": [
-126
-],
-"top": 15,
-"width": 164
-},
-"106": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-208,
-112
-],
-"keyEmpty": [
-"keyboard-key-empty",
-"keyboard-key-empty",
-"keyboard-key-empty",
-"keyboard-key-empty",
-"keyboard-key-empty"
-],
-"keyHash": [
-"5192296858534827628530496329220096"
-],
-"keyName": "4",
-"left": 275,
-"packetIndex": [
-57
-],
-"top": 15,
-"width": 65
-},
-"107": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-210,
-113
-],
-"keyHash": [
-"10384593717069655257060992658440192"
-],
-"keyName": "5",
-"left": 15,
-"packetIndex": [
-69
-],
-"top": 15,
-"width": 65
-},
-"108": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-212,
-114
-],
-"keyHash": [
-"20769187434139310514121985316880384"
-],
-"keyName": "6",
-"left": 15,
-"packetIndex": [
-81
-],
-"top": 15,
-"width": 65
-}
-}
-},
-"5": {
-"keys": {
-"109": {
-"color": {
-"blue": 0,
-"green": 255,
-"red": 255
-},
-"default": true,
-"height": 70,
-"keyData": [
-96,
-48
-],
-"keyHash": [
-"281474976710656"
-],
-"keyName": "Shift",
-"keySpace": "keyboard-key wide",
-"left": 15,
-"packetIndex": [
-4
-],
-"top": 15,
-"width": 170
-},
-"110": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-98,
-49
-],
-"keyHash": [
-"562949953421312"
-],
-"keyName": "< >",
-"left": 15,
-"packetIndex": [
-16
-],
-"top": 15,
-"width": 65
-},
-"111": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-100,
-50
-],
-"keyHash": [
-"1125899906842624"
-],
-"keyName": "W",
-"left": 15,
-"packetIndex": [
-28
-],
-"top": 15,
-"width": 65
-},
-"112": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-100,
-51
-],
-"keyHash": [
-"2251799813685248"
-],
-"keyName": "X",
-"left": 15,
-"packetIndex": [
-40
-],
-"top": 15,
-"width": 65
-},
-"113": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-102,
-52
-],
-"keyHash": [
-"4503599627370496"
-],
-"keyName": "C",
-"left": 15,
-"packetIndex": [
-52
-],
-"top": 15,
-"width": 65
-},
-"114": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-104,
-53
-],
-"keyHash": [
-"9007199254740992"
-],
-"keyName": "V",
-"left": 15,
-"packetIndex": [
-64
-],
-"top": 15,
-"width": 65
-},
-"115": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-106,
-54
-],
-"keyHash": [
-"18014398509481984"
-],
-"keyName": "B",
-"left": 15,
-"packetIndex": [
-76
-],
-"top": 15,
-"width": 65
-},
-"116": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-108,
-55
-],
-"keyHash": [
-"36028797018963968"
-],
-"keyName": "N",
-"left": 15,
-"packetIndex": [
-88
-],
-"top": 15,
-"width": 65
-},
-"117": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-110,
-56
-],
-"keyHash": [
-"72057594037927936"
-],
-"keyName": ", ?",
-"left": 15,
-"packetIndex": [
-100
-],
-"top": 15,
-"width": 65
-},
-"118": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-112,
-57
-],
-"keyHash": [
-"144115188075855872"
-],
-"keyName": "; .",
-"left": 15,
-"packetIndex": [
-112
-],
-"top": 15,
-"width": 65
-},
-"119": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-114,
-58
-],
-"keyHash": [
-"288230376151711744"
-],
-"keyName": ": /",
-"left": 15,
-"packetIndex": [
-124
-],
-"top": 15,
-"width": 65
-},
-"120": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-116,
-59
-],
-"keyHash": [
-"576460752303423488"
-],
-"keyName": "! §",
-"left": 15,
-"packetIndex": [
-136
-],
-"top": 15,
-"width": 65
-},
-"121": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-166,
-90
-],
-"keyHash": [
-"1237940039285380274899124224"
-],
-"keyName": "Shift",
-"keySpace": "keyboard-key wide3",
-"left": 15,
-"packetIndex": [
-79
-],
-"top": 15,
-"width": 205
-},
-"122": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-170,
-92
-],
-"keyEmpty": [
-"keyboard-key-empty",
-"keyboard-key-empty"
-],
-"keyHash": [
-"4951760157141521099596496896"
-],
-"keyName": "↑",
-"left": 105,
-"packetIndex": [
-103
-],
-"top": 15,
-"width": 65
-},
-"123": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-214,
-115
-],
-"keyEmpty": [
-"keyboard-key-empty",
-"keyboard-key-empty"
-],
-"keyHash": [
-"41538374868278621028243970633760768"
-],
-"keyName": "1",
-"left": 105,
-"packetIndex": [
-93
-],
-"top": 15,
-"width": 65
-},
-"124": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-216,
-116
-],
-"keyHash": [
-"83076749736557242056487941267521536"
-],
-"keyName": "2",
-"left": 15,
-"packetIndex": [
-105
-],
-"top": 15,
-"width": 65
-},
-"125": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-218,
-117
-],
-"keyHash": [
-"166153499473114484112975882535043072"
-],
-"keyName": "3",
-"left": 15,
-"packetIndex": [
-117
-],
-"top": 15,
-"width": 65
-},
-"126": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 155,
-"keyData": [
-200,
-107
-],
-"keyHash": [
-"162259276829213363391578010288128"
-],
-"keyName": "Enter",
-"keySpace": "keyboard-key-125",
-"left": 15,
-"packetIndex": [
-140
-],
-"top": 15,
-"width": 65
-}
-},
-"top": 65
-},
-"6": {
-"keys": {
-"127": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-118,
-60
-],
-"keyHash": [
-"1152921504606846976"
-],
-"keyName": "Ctrl",
-"keySpace": "keyboard-key wide",
-"left": 15,
-"packetIndex": [
-5
-],
-"top": 15,
-"width": 90
-},
-"128": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-120,
-61
-],
-"keyHash": [
-"2305843009213693952"
-],
-"keyName": "Win",
-"left": 15,
-"packetIndex": [
-17
-],
-"top": 15,
-"width": 90
-},
-"129": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-122,
-62
-],
-"keyHash": [
-"4611686018427387904"
-],
-"keyName": "Alt",
-"keySpace": "keyboard-key wide",
-"left": 15,
-"packetIndex": [
-29
-],
-"top": 15,
-"width": 90
-},
-"130": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-124,
-64
-],
-"keyHash": [
-"18446744073709551616"
-],
-"keyName": "----------",
-"keySpace": "keyboard-key wide6",
-"left": 15,
-"packetIndex": [
-53
-],
-"top": 15,
-"width": 151
-},
-"131": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-126,
-67
-],
-"keyHash": [
-"147573952589676412928"
-],
-"keyName": "AltGr",
-"left": 15,
-"packetIndex": [
-89
-],
-"top": 15,
-"width": 90
-},
-"132": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-128,
-68
-],
-"keyHash": [
-"295147905179352825856"
-],
-"keyName": "Win",
-"left": 15,
-"packetIndex": [
-101
-],
-"top": 15,
-"width": 90
-},
-"133": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-130,
-69
-],
-"keyHash": [
-"590295810358705651712"
-],
-"keyName": "Menu",
-"left": 15,
-"packetIndex": [
-113
-],
-"top": 15,
-"width": 90
-},
-"134": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-168,
-91
-],
-"keyHash": [
-"2475880078570760549798248448"
-],
-"keyName": "Ctrl",
-"keySpace": "keyboard-key wide",
-"left": 15,
-"packetIndex": [
-91
-],
-"top": 15,
-"width": 90
-},
-"135": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-172,
-93
-],
-"keyEmpty": [
-"keyboard-key-empty"
-],
-"keyHash": [
-"9903520314283042199192993792"
-],
-"keyName": "←",
-"left": 25,
-"packetIndex": [
-115
-],
-"top": 15,
-"width": 65
-},
-"136": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-174,
-94
-],
-"keyHash": [
-"19807040628566084398385987584"
-],
-"keyName": "↓",
-"left": 15,
-"packetIndex": [
-127
-],
-"top": 15,
-"width": 65
-},
-"137": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-176,
-95
-],
-"keyHash": [
-"39614081257132168796771975168"
-],
-"keyName": "→",
-"left": 15,
-"packetIndex": [
-139
-],
-"top": 15,
-"width": 65
-},
-"138": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-220,
-118
-],
-"keyEmpty": [
-"keyboard-key-empty"
-],
-"keyHash": [
-"332306998946228968225951765070086144"
-],
-"keyName": "0",
-"keySpace": "keyboard-key wide",
-"left": 25,
-"packetIndex": [
-129
-],
-"top": 15,
-"width": 145
-},
-"139": {
-"color": {
-"blue": 255,
-"green": 255,
-"red": 0
-},
-"default": true,
-"height": 70,
-"keyData": [
-222,
-119
-],
-"keyHash": [
-"664613997892457936451903530140172288"
-],
-"keyName": ".",
-"left": 15,
-"packetIndex": [
-141
-],
-"top": 15,
-"width": 65
-}
-}
-}
-},
-"rows": 6,
-"uppercaseClass": "key-uppercase",
-"version": 2
+  "version": 2,
+  "uppercaseClass": "key-uppercase",
+  "fontSize": 14,
+  "key": "k70mk2-default",
+  "device": "K70 MK2",
+  "layout": "FR",
+  "rows": 6,
+  "row": {
+    "0": {
+      "keys": {
+        "1": {
+          "keyName": "PF",
+          "width": 65,
+          "height": 40,
+          "left": 0,
+          "top": 0,
+          "packetIndex": [125],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyEmpty": [
+            "keyboard-key-empty",
+            "keyboard-key-empty",
+            "keyboard-key-empty"
+          ],
+          "onlyColor": true
+        },
+        "2": {
+          "keyName": "BTS",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [137],
+          "keyData": [134,71],
+          "default": true,
+          "noColor": false,
+          "customKeyData": 193,
+          "keyHash": ["2361183241434822606848"],
+          "actionType": 11,
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "onlyColor": true
+        },
+        "3": {
+          "keyName": "LOCK",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [8],
+          "keyData": [178,96],
+          "default": true,
+          "keyHash": ["79228162514264337593543950336"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "isLock": true,
+          "onlyColor": true
+        },
+        "4": {
+          "keyName": "LOGO",
+          "width": 202,
+          "height": 40,
+          "left": 400,
+          "top": 0,
+          "packetIndex": [47],
+          "color": {
+            "red": 255,
+            "green": 255,
+            "blue": 0
+          },
+          "keyEmpty": [
+            "keyboard-key-empty",
+            "keyboard-key-empty",
+            "keyboard-key-empty"
+          ],
+          "keySpace": "keyboard-key wide3",
+          "onlyColor": true
+        },
+        "5": {
+          "keyName": "LOGO",
+          "width": 202,
+          "height": 40,
+          "left": 0,
+          "top": 0,
+          "packetIndex": [59],
+          "color": {
+            "red": 255,
+            "green": 255,
+            "blue": 0
+          },
+          "keySpace": "keyboard-key wide3",
+          "onlyColor": true
+        },
+        "6": {
+          "keyName": "MUTE",
+          "width": 65,
+          "height": 40,
+          "left": 436,
+          "top": 0,
+          "packetIndex": [20],
+          "keyData": [180,97],
+          "default": true,
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyEmpty": [
+            "keyboard-key-empty",
+            "keyboard-key-empty",
+            "keyboard-key-empty",
+            "keyboard-key-empty",
+            "keyboard-key-empty",
+            "keyboard-key-empty"
+          ]
+        },
+        "7": {
+          "keyName": "W +",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "keyData": [236,130],
+          "default": true,
+          "noColor": true,
+          "keyHash": ["1361129467683753853853498429727072845824"]
+        },
+        "8": {
+          "keyName": "W -",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "keyData": [238,131],
+          "default": true,
+          "noColor": true,
+          "keyHash": ["2722258935367507707706996859454145691648"]
+        }
+      }
+    },
+    "1": {
+      "keys": {
+        "27": {
+          "keyName": "ESC",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [0],
+          "keyData": [0,0],
+          "default": true,
+          "keyHash": ["1"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 0
+          }
+        },
+        "28": {
+          "keyName": "F1",
+          "width": 65,
+          "height": 70,
+          "left": 95,
+          "top": 0,
+          "packetIndex": [12],
+          "keyData": [2,1],
+          "default": true,
+          "keyEmpty": ["keyboard-key-empty"],
+          "keyHash": ["2"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "29": {
+          "keyName": "F2",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [24],
+          "keyData": [4,2],
+          "default": true,
+          "keyHash": ["4"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "30": {
+          "keyName": "F3",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [36],
+          "keyData": [6,3],
+          "default": true,
+          "keyHash": ["8"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "31": {
+          "keyName": "F4",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [48],
+          "keyData": [8,4],
+          "default": true,
+          "keyHash": ["16"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "32": {
+          "keyName": "F5",
+          "width": 65,
+          "height": 70,
+          "left": 55,
+          "top": 0,
+          "packetIndex": [60],
+          "keyData": [10,5],
+          "default": true,
+          "keyEmpty": ["keyboard-key-empty"],
+          "keyHash": ["32"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "33": {
+          "keyName": "F6",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [72],
+          "keyData": [12,6],
+          "default": true,
+          "keyHash": ["64"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "34": {
+          "keyName": "F7",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [84],
+          "keyData": [14,7],
+          "default": true,
+          "keyHash": ["128"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "35": {
+          "keyName": "F8",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [96],
+          "keyData": [16,8],
+          "default": true,
+          "keyHash": ["256"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "36": {
+          "keyName": "F9",
+          "width": 65,
+          "height": 70,
+          "left": 60,
+          "top": 0,
+          "packetIndex": [108],
+          "keyData": [18,9],
+          "default": true,
+          "keyEmpty": ["keyboard-key-empty"],
+          "keyHash": ["512"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "37": {
+          "keyName": "F10",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [120],
+          "keyData": [20,10],
+          "default": true,
+          "keyHash": ["1024"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "38": {
+          "keyName": "F11",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [132],
+          "keyData": [22,11],
+          "default": true,
+          "keyHash": ["2048"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "39": {
+          "keyName": "F12",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [6],
+          "keyData": [136,72],
+          "default": true,
+          "keyHash": ["4722366482869645213696"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "40": {
+          "keyName": "PrtSc",
+          "width": 65,
+          "height": 70,
+          "left": 25,
+          "top": 0,
+          "packetIndex": [18],
+          "keyData": [138,73],
+          "default": true,
+          "keyEmpty": ["keyboard-key-empty"],
+          "keyHash": ["9444732965739290427392"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "41": {
+          "keyName": "ScrLk",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [30],
+          "keyData": [140,74],
+          "default": true,
+          "keyHash": ["18889465931478580854784"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "42": {
+          "keyName": "Pause",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [42],
+          "keyData": [142,75],
+          "default": true,
+          "keyHash": ["37778931862957161709568"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "43": {
+          "keyName": "Stop",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [32],
+          "keyData": [182,98],
+          "default": true,
+          "keyEmpty": ["keyboard-key-empty"],
+          "keyHash": ["316912650057057350374175801344"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "44": {
+          "keyName": "Prev",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [44],
+          "keyData": [184,99],
+          "default": true,
+          "keyHash": ["633825300114114700748351602688"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "45": {
+          "keyName": "Play",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [56],
+          "keyData": [186,100],
+          "default": true,
+          "keyHash": ["1267650600228229401496703205376"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "46": {
+          "keyName": "Next",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [68],
+          "keyData": [188,101],
+          "default": true,
+          "keyHash": ["2535301200456458802993406410752"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        }
+      }
+    },
+    "2": {
+      "keys": {
+        "48": {
+          "keyName": "²",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [1],
+          "keyData": [24,12],
+          "default": true,
+          "keyHash": ["4096"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "49": {
+          "keyName": "& 1",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [13],
+          "keyData": [26,13],
+          "default": true,
+          "keyHash": ["8192"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "50": {
+          "keyName": "é 2 ~",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [25],
+          "keyData": [28,14],
+          "default": true,
+          "keyHash": ["16384"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "51": {
+          "keyName": "\" 3 #",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [37],
+          "keyData": [30,15],
+          "default": true,
+          "keyHash": ["32768"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "52": {
+          "keyName": "' 4 {",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [49],
+          "keyData": [32,16],
+          "default": true,
+          "keyHash": ["65536"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "53": {
+          "keyName": "( 5 [",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [61],
+          "keyData": [34,17],
+          "default": true,
+          "keyHash": ["131072"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "54": {
+          "keyName": "- 6 |",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [73],
+          "keyData": [36,18],
+          "default": true,
+          "keyHash": ["262144"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "55": {
+          "keyName": "è 7 `",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [85],
+          "keyData": [38,19],
+          "default": true,
+          "keyHash": ["524288"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "56": {
+          "keyName": "_ 8 \\",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [97],
+          "keyData": [40,20],
+          "default": true,
+          "keyHash": ["1048576"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "57": {
+          "keyName": "ç 9 ^",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [109],
+          "keyData": [42,21],
+          "default": true,
+          "keyHash": ["2097152"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "58": {
+          "keyName": "à 0 @",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [121],
+          "keyData": [44,22],
+          "default": true,
+          "keyHash": ["4194304"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "59": {
+          "keyName": ") ° ]",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [133],
+          "keyData": [46,23],
+          "default": true,
+          "keyHash": ["8388608"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "60": {
+          "keyName": "= + }",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [7],
+          "keyData": [156,84],
+          "default": true,
+          "keyHash": ["19342813113834066795298816"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "61": {
+          "keyName": "<---",
+          "width": 150,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [31],
+          "keyData": [158,86],
+          "default": true,
+          "keySpace": "keyboard-key wide3",
+          "keyHash": ["77371252455336267181195264"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "62": {
+          "keyName": "Ins",
+          "width": 65,
+          "height": 70,
+          "left": 25,
+          "top": 15,
+          "packetIndex": [54],
+          "keyData": [144,76],
+          "default": true,
+          "keyEmpty": ["keyboard-key-empty"],
+          "keyHash": ["75557863725914323419136"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "63": {
+          "keyName": "Home",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [66],
+          "keyData": [146,77],
+          "default": true,
+          "keyHash": ["151115727451828646838272"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "64": {
+          "keyName": "PgUp",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [78],
+          "keyData": [148,78],
+          "default": true,
+          "keyHash": ["302231454903657293676544"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "65": {
+          "keyName": "Num",
+          "width": 65,
+          "height": 70,
+          "left": 25,
+          "top": 15,
+          "packetIndex": [80],
+          "keyData": [190,102],
+          "default": true,
+          "keyEmpty": ["keyboard-key-empty"],
+          "keyHash": ["5070602400912917605986812821504"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "66": {
+          "keyName": "/",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [92],
+          "keyData": [192,103],
+          "default": true,
+          "keyHash": ["10141204801825835211973625643008"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "67": {
+          "keyName": "*",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [104],
+          "keyData": [194,104],
+          "default": true,
+          "keyHash": ["20282409603651670423947251286016"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "68": {
+          "keyName": "-",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [116],
+          "keyData": [196,105],
+          "default": true,
+          "keyHash": ["40564819207303340847894502572032"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        }
+      }
+    },
+    "3": {
+      "top": 65,
+      "keys": {
+        "70": {
+          "keyName": "Tab",
+          "width": 108,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [2],
+          "keyData": [48,24],
+          "default": true,
+          "keySpace": "keyboard-key wide",
+          "keyHash": ["16777216"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "71": {
+          "keyName": "A",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [14],
+          "keyData": [50,25],
+          "default": true,
+          "keyHash": ["33554432"],
+          "color": {
+            "red": 255,
+            "green": 0,
+            "blue": 0
+          }
+        },
+        "72": {
+          "keyName": "Z",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [26],
+          "keyData": [52,26],
+          "default": true,
+          "keyHash": ["67108864"],
+          "color": {
+            "red": 255,
+            "green": 0,
+            "blue": 0
+          }
+        },
+        "73": {
+          "keyName": "E €",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [38],
+          "keyData": [54,27],
+          "default": true,
+          "keyHash": ["134217728"],
+          "color": {
+            "red": 255,
+            "green": 0,
+            "blue": 0
+          }
+        },
+        "74": {
+          "keyName": "R",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [50],
+          "keyData": [56,28],
+          "default": true,
+          "keyHash": ["268435456"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "75": {
+          "keyName": "T",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [62],
+          "keyData": [58,29],
+          "default": true,
+          "keyHash": ["536870912"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "76": {
+          "keyName": "Y",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [74],
+          "keyData": [60,30],
+          "default": true,
+          "keyHash": ["1073741824"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "77": {
+          "keyName": "U",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [86],
+          "keyData": [62,31],
+          "default": true,
+          "keyHash": ["2147483648"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "78": {
+          "keyName": "I",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [98],
+          "keyData": [64,32],
+          "default": true,
+          "keyHash": ["4294967296"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "79": {
+          "keyName": "O",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [110],
+          "keyData": [66,33],
+          "default": true,
+          "keyHash": ["8589934592"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "80": {
+          "keyName": "P",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [122],
+          "keyData": [68,34],
+          "default": true,
+          "keyHash": ["17179869184"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "81": {
+          "keyName": "^ ¨",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [134],
+          "keyData": [70,35],
+          "default": true,
+          "keyHash": ["34359738368"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "82": {
+          "keyName": "$ £ ¤",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [90],
+          "keyData": [150,79],
+          "default": true,
+          "keyHash": ["604462909807314587353088"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "84": {
+          "keyName": "Del",
+          "width": 65,
+          "height": 70,
+          "left": 25,
+          "top": 15,
+          "packetIndex": [43],
+          "keyData": [160,87],
+          "default": true,
+          "keyEmpty": ["keyboard-key-empty", "keyboard-key-empty", "keyboard-key-empty"],
+          "keyHash": ["154742504910672534362390528"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "85": {
+          "keyName": "End",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [55],
+          "keyData": [162,88],
+          "default": true,
+          "keyHash": ["309485009821345068724781056"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "86": {
+          "keyName": "PgDn",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [67],
+          "keyData": [164,89],
+          "default": true,
+          "keyHash": ["618970019642690137449562112"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "87": {
+          "keyName": "7",
+          "width": 65,
+          "height": 70,
+          "left": 25,
+          "top": 15,
+          "packetIndex": [9],
+          "keyData": [202,108],
+          "default": true,
+          "keyEmpty": ["keyboard-key-empty"],
+          "keyHash": ["324518553658426726783156020576256"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "88": {
+          "keyName": "8",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [21],
+          "keyData": [204,109],
+          "default": true,
+          "keyHash": ["649037107316853453566312041152512"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "89": {
+          "keyName": "9",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [33],
+          "keyData": [206,110],
+          "default": true,
+          "keyHash": ["1298074214633706907132624082305024"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "90": {
+          "keyName": "+",
+          "width": 65,
+          "height": 155,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [128],
+          "keyData": [198,106],
+          "default": true,
+          "keyHash": ["81129638414606681695789005144064"],
+          "keySpace": "keyboard-key-125",
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        }
+      }
+    },
+    "4": {
+      "css": "keyboard-row-25",
+      "keys": {
+        "92": {
+          "keyName": "CAPS",
+          "width": 131,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [3],
+          "keyData": [72,36],
+          "default": true,
+          "keySpace": "keyboard-key wide",
+          "keyHash": ["68719476736"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "93": {
+          "keyName": "Q",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [15],
+          "keyData": [74,37],
+          "default": true,
+          "keyHash": ["137438953472"],
+          "color": {
+            "red": 255,
+            "green": 0,
+            "blue": 0
+          }
+        },
+        "94": {
+          "keyName": "S",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [27],
+          "keyData": [76,38],
+          "default": true,
+          "keyHash": ["274877906944"],
+          "color": {
+            "red": 255,
+            "green": 0,
+            "blue": 0
+          }
+        },
+        "95": {
+          "keyName": "D",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [39],
+          "keyData": [78,39],
+          "default": true,
+          "keyHash": ["549755813888"],
+          "color": {
+            "red": 255,
+            "green": 0,
+            "blue": 0
+          }
+        },
+        "96": {
+          "keyName": "F",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [51],
+          "keyData": [80,40],
+          "default": true,
+          "keyHash": ["1099511627776"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "97": {
+          "keyName": "G",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [63],
+          "keyData": [82,41],
+          "default": true,
+          "keyHash": ["2199023255552"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "98": {
+          "keyName": "H",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [75],
+          "keyData": [84,42],
+          "default": true,
+          "keyHash": ["4398046511104"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "99": {
+          "keyName": "J",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [87],
+          "keyData": [86,43],
+          "default": true,
+          "keyHash": ["8796093022208"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "100": {
+          "keyName": "K",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [99],
+          "keyData": [88,44],
+          "default": true,
+          "keyHash": ["17592186044416"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "101": {
+          "keyName": "L",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [111],
+          "keyData": [90,45],
+          "default": true,
+          "keyHash": ["35184372088832"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "102": {
+          "keyName": "M",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [123],
+          "keyData": [92,46],
+          "default": true,
+          "keyHash": ["70368744177664"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "103": {
+          "keyName": "ù %",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [135],
+          "keyData": [94,47],
+          "default": true,
+          "keyHash": ["140737488355328"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "104": {
+          "keyName": "* µ",
+          "width": 107,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [114],
+          "keyData": [162,81],
+          "default": true,
+          "keyHash": ["2417851639229258349412352"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "105": {
+          "keyName": "Enter",
+          "width": 164,
+          "height": 155,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [126],
+          "keyData": [154,82],
+          "default": true,
+          "keyHash": ["4835703278458516698824704"],
+          "keySpace": "keyboard-key wide",
+          "css": "enter-custom",
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "106": {
+          "keyName": "4",
+          "width": 65,
+          "height": 70,
+          "left": 275,
+          "top": 15,
+          "packetIndex": [57],
+          "keyData": [208,112],
+          "default": true,
+          "keyEmpty": ["keyboard-key-empty","keyboard-key-empty","keyboard-key-empty","keyboard-key-empty","keyboard-key-empty"],
+          "keyHash": ["5192296858534827628530496329220096"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "107": {
+          "keyName": "5",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [69],
+          "keyData": [210,113],
+          "default": true,
+          "keyHash": ["10384593717069655257060992658440192"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "108": {
+          "keyName": "6",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [81],
+          "keyData": [212,114],
+          "default": true,
+          "keyHash": ["20769187434139310514121985316880384"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        }
+      }
+    },
+    "5": {
+      "top": 65,
+      "keys": {
+        "109": {
+          "keyName": "Shift",
+          "width": 170,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [4],
+          "keyData": [96,48],
+          "default": true,
+          "keySpace": "keyboard-key wide",
+          "keyHash": ["281474976710656"],
+          "color": {
+            "red": 255,
+            "green": 255,
+            "blue": 0
+          }
+        },
+        "110": {
+          "keyName": "< >",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [16],
+          "keyData": [98,49],
+          "default": true,
+          "keyHash": ["562949953421312"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "111": {
+          "keyName": "W",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [28],
+          "keyData": [100,50],
+          "default": true,
+          "keyHash": ["1125899906842624"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "112": {
+          "keyName": "X",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [40],
+          "keyData": [100,51],
+          "default": true,
+          "keyHash": ["2251799813685248"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "113": {
+          "keyName": "C",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [52],
+          "keyData": [102,52],
+          "default": true,
+          "keyHash": ["4503599627370496"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "114": {
+          "keyName": "V",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [64],
+          "keyData": [104,53],
+          "default": true,
+          "keyHash": ["9007199254740992"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "115": {
+          "keyName": "B",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [76],
+          "keyData": [106,54],
+          "default": true,
+          "keyHash": ["18014398509481984"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "116": {
+          "keyName": "N",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [88],
+          "keyData": [108,55],
+          "default": true,
+          "keyHash": ["36028797018963968"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "117": {
+          "keyName": ", ?",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [100],
+          "keyData": [110,56],
+          "default": true,
+          "keyHash": ["72057594037927936"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "118": {
+          "keyName": "; .",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [112],
+          "keyData": [112,57],
+          "default": true,
+          "keyHash": ["144115188075855872"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "119": {
+          "keyName": ": /",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [124],
+          "keyData": [114,58],
+          "default": true,
+          "keyHash": ["288230376151711744"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "120": {
+          "keyName": "! §",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [136],
+          "keyData": [116,59],
+          "default": true,
+          "keyHash": ["576460752303423488"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "121": {
+          "keyName": "Shift",
+          "width": 205,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [79],
+          "keyData": [166,90],
+          "default": true,
+          "keySpace": "keyboard-key wide3",
+          "keyHash": ["1237940039285380274899124224"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "122": {
+          "keyName": "↑",
+          "width": 65,
+          "height": 70,
+          "left": 105,
+          "top": 15,
+          "packetIndex": [103],
+          "keyData": [170,92],
+          "default": true,
+          "keyEmpty": ["keyboard-key-empty","keyboard-key-empty"],
+          "keyHash": ["4951760157141521099596496896"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "123": {
+          "keyName": "1",
+          "width": 65,
+          "height": 70,
+          "left": 105,
+          "top": 15,
+          "packetIndex": [93],
+          "keyData": [214,115],
+          "default": true,
+          "keyEmpty": ["keyboard-key-empty","keyboard-key-empty"],
+          "keyHash": ["41538374868278621028243970633760768"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "124": {
+          "keyName": "2",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [105],
+          "keyData": [216,116],
+          "default": true,
+          "keyHash": ["83076749736557242056487941267521536"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "125": {
+          "keyName": "3",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [117],
+          "keyData": [218,117],
+          "default": true,
+          "keyHash": ["166153499473114484112975882535043072"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "126": {
+          "keyName": "Enter",
+          "width": 65,
+          "height": 155,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [140],
+          "keyData": [200,107],
+          "default": true,
+          "keySpace": "keyboard-key-125",
+          "keyHash": ["162259276829213363391578010288128"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        }
+      }
+    },
+    "6": {
+      "keys": {
+        "127": {
+          "keyName": "Ctrl",
+          "width": 90,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [5],
+          "keyData": [118,60],
+          "default": true,
+          "keySpace": "keyboard-key wide",
+          "keyHash": ["1152921504606846976"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "128": {
+          "keyName": "Win",
+          "width": 90,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [17],
+          "keyData": [120,61],
+          "default": true,
+          "keyHash": ["2305843009213693952"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "129": {
+          "keyName": "Alt",
+          "width": 90,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [29],
+          "keyData": [122,62],
+          "default": true,
+          "keySpace": "keyboard-key wide",
+          "keyHash": ["4611686018427387904"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "130": {
+          "keyName": "----------",
+          "width": 151,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [53],
+          "keyData": [124,64],
+          "default": true,
+          "keySpace": "keyboard-key wide6",
+          "keyHash": ["18446744073709551616"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "131": {
+          "keyName": "AltGr",
+          "width": 90,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [89],
+          "keyData": [126,67],
+          "default": true,
+          "keyHash": ["147573952589676412928"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "132": {
+          "keyName": "Win",
+          "width": 90,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [101],
+          "keyData": [128,68],
+          "default": true,
+          "keyHash": ["295147905179352825856"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "133": {
+          "keyName": "Menu",
+          "width": 90,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [113],
+          "keyData": [130,69],
+          "default": true,
+          "keyHash": ["590295810358705651712"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "134": {
+          "keyName": "Ctrl",
+          "width": 90,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [91],
+          "keyData": [168,91],
+          "default": true,
+          "keySpace": "keyboard-key wide",
+          "keyHash": ["2475880078570760549798248448"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "135": {
+          "keyName": "←",
+          "width": 65,
+          "height": 70,
+          "left": 25,
+          "top": 15,
+          "packetIndex": [115],
+          "keyData": [172,93],
+          "default": true,
+          "keyEmpty": ["keyboard-key-empty"],
+          "keyHash": ["9903520314283042199192993792"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "136": {
+          "keyName": "↓",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [127],
+          "keyData": [174,94],
+          "default": true,
+          "keyHash": ["19807040628566084398385987584"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "137": {
+          "keyName": "→",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [139],
+          "keyData": [176,95],
+          "default": true,
+          "keyHash": ["39614081257132168796771975168"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "138": {
+          "keyName": "0",
+          "width": 145,
+          "height": 70,
+          "left": 25,
+          "top": 15,
+          "packetIndex": [129],
+          "keyData": [220,118],
+          "default": true,
+          "keyEmpty": ["keyboard-key-empty"],
+          "keySpace": "keyboard-key wide",
+          "keyHash": ["332306998946228968225951765070086144"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "139": {
+          "keyName": ".",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [141],
+          "keyData": [222,119],
+          "default": true,
+          "keyHash": ["664613997892457936451903530140172288"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        }
+      }
+    }
+  }
 }

--- a/database/keyboard/k70mk2-fr.json
+++ b/database/keyboard/k70mk2-fr.json
@@ -1,0 +1,2785 @@
+{
+"device": "K70 MK2",
+"fontSize": 14,
+"key": "k70mk2-default",
+"layout": "FR",
+"row": {
+"0": {
+"keys": {
+"1": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"height": 40,
+"keyEmpty": [
+"keyboard-key-empty",
+"keyboard-key-empty",
+"keyboard-key-empty"
+],
+"keyName": "PF",
+"left": 0,
+"onlyColor": true,
+"packetIndex": [
+125
+],
+"top": 0,
+"width": 65
+},
+"2": {
+"actionType": 11,
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"customKeyData": 193,
+"default": true,
+"height": 70,
+"keyData": [
+134,
+71
+],
+"keyHash": [
+"2361183241434822606848"
+],
+"keyName": "BTS",
+"left": 15,
+"noColor": false,
+"onlyColor": true,
+"packetIndex": [
+137
+],
+"top": 0,
+"width": 65
+},
+"3": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"isLock": true,
+"keyData": [
+178,
+96
+],
+"keyHash": [
+"79228162514264337593543950336"
+],
+"keyName": "LOCK",
+"left": 15,
+"onlyColor": true,
+"packetIndex": [
+8
+],
+"top": 0,
+"width": 65
+},
+"4": {
+"color": {
+"blue": 0,
+"green": 255,
+"red": 255
+},
+"height": 40,
+"keyEmpty": [
+"keyboard-key-empty",
+"keyboard-key-empty",
+"keyboard-key-empty"
+],
+"keyName": "LOGO",
+"keySpace": "keyboard-key wide3",
+"left": 400,
+"onlyColor": true,
+"packetIndex": [
+47
+],
+"top": 0,
+"width": 202
+},
+"5": {
+"color": {
+"blue": 0,
+"green": 255,
+"red": 255
+},
+"height": 40,
+"keyName": "LOGO",
+"keySpace": "keyboard-key wide3",
+"left": 0,
+"onlyColor": true,
+"packetIndex": [
+59
+],
+"top": 0,
+"width": 202
+},
+"6": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 40,
+"keyData": [
+180,
+97
+],
+"keyEmpty": [
+"keyboard-key-empty",
+"keyboard-key-empty",
+"keyboard-key-empty",
+"keyboard-key-empty",
+"keyboard-key-empty",
+"keyboard-key-empty"
+],
+"keyName": "MUTE",
+"left": 436,
+"packetIndex": [
+20
+],
+"top": 0,
+"width": 65
+},
+"7": {
+"default": true,
+"height": 70,
+"keyData": [
+236,
+130
+],
+"keyHash": [
+"1361129467683753853853498429727072845824"
+],
+"keyName": "W +",
+"left": 15,
+"noColor": true,
+"top": 0,
+"width": 65
+},
+"8": {
+"default": true,
+"height": 70,
+"keyData": [
+238,
+131
+],
+"keyHash": [
+"2722258935367507707706996859454145691648"
+],
+"keyName": "W -",
+"left": 15,
+"noColor": true,
+"top": 0,
+"width": 65
+}
+}
+},
+"1": {
+"keys": {
+"27": {
+"color": {
+"blue": 0,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+0,
+0
+],
+"keyHash": [
+"1"
+],
+"keyName": "ESC",
+"left": 15,
+"packetIndex": [
+0
+],
+"top": 0,
+"width": 65
+},
+"28": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+2,
+1
+],
+"keyEmpty": [
+"keyboard-key-empty"
+],
+"keyHash": [
+"2"
+],
+"keyName": "F1",
+"left": 95,
+"packetIndex": [
+12
+],
+"top": 0,
+"width": 65
+},
+"29": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+4,
+2
+],
+"keyHash": [
+"4"
+],
+"keyName": "F2",
+"left": 15,
+"packetIndex": [
+24
+],
+"top": 0,
+"width": 65
+},
+"30": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+6,
+3
+],
+"keyHash": [
+"8"
+],
+"keyName": "F3",
+"left": 15,
+"packetIndex": [
+36
+],
+"top": 0,
+"width": 65
+},
+"31": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+8,
+4
+],
+"keyHash": [
+"16"
+],
+"keyName": "F4",
+"left": 15,
+"packetIndex": [
+48
+],
+"top": 0,
+"width": 65
+},
+"32": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+10,
+5
+],
+"keyEmpty": [
+"keyboard-key-empty"
+],
+"keyHash": [
+"32"
+],
+"keyName": "F5",
+"left": 55,
+"packetIndex": [
+60
+],
+"top": 0,
+"width": 65
+},
+"33": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+12,
+6
+],
+"keyHash": [
+"64"
+],
+"keyName": "F6",
+"left": 15,
+"packetIndex": [
+72
+],
+"top": 0,
+"width": 65
+},
+"34": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+14,
+7
+],
+"keyHash": [
+"128"
+],
+"keyName": "F7",
+"left": 15,
+"packetIndex": [
+84
+],
+"top": 0,
+"width": 65
+},
+"35": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+16,
+8
+],
+"keyHash": [
+"256"
+],
+"keyName": "F8",
+"left": 15,
+"packetIndex": [
+96
+],
+"top": 0,
+"width": 65
+},
+"36": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+18,
+9
+],
+"keyEmpty": [
+"keyboard-key-empty"
+],
+"keyHash": [
+"512"
+],
+"keyName": "F9",
+"left": 60,
+"packetIndex": [
+108
+],
+"top": 0,
+"width": 65
+},
+"37": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+20,
+10
+],
+"keyHash": [
+"1024"
+],
+"keyName": "F10",
+"left": 15,
+"packetIndex": [
+120
+],
+"top": 0,
+"width": 65
+},
+"38": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+22,
+11
+],
+"keyHash": [
+"2048"
+],
+"keyName": "F11",
+"left": 15,
+"packetIndex": [
+132
+],
+"top": 0,
+"width": 65
+},
+"39": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+136,
+72
+],
+"keyHash": [
+"4722366482869645213696"
+],
+"keyName": "F12",
+"left": 15,
+"packetIndex": [
+6
+],
+"top": 0,
+"width": 65
+},
+"40": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+138,
+73
+],
+"keyEmpty": [
+"keyboard-key-empty"
+],
+"keyHash": [
+"9444732965739290427392"
+],
+"keyName": "PrtSc",
+"left": 25,
+"packetIndex": [
+18
+],
+"top": 0,
+"width": 65
+},
+"41": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+140,
+74
+],
+"keyHash": [
+"18889465931478580854784"
+],
+"keyName": "ScrLk",
+"left": 15,
+"packetIndex": [
+30
+],
+"top": 0,
+"width": 65
+},
+"42": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+142,
+75
+],
+"keyHash": [
+"37778931862957161709568"
+],
+"keyName": "Pause",
+"left": 15,
+"packetIndex": [
+42
+],
+"top": 0,
+"width": 65
+},
+"43": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+182,
+98
+],
+"keyEmpty": [
+"keyboard-key-empty"
+],
+"keyHash": [
+"316912650057057350374175801344"
+],
+"keyName": "Stop",
+"left": 15,
+"packetIndex": [
+32
+],
+"top": 0,
+"width": 65
+},
+"44": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+184,
+99
+],
+"keyHash": [
+"633825300114114700748351602688"
+],
+"keyName": "Prev",
+"left": 15,
+"packetIndex": [
+44
+],
+"top": 0,
+"width": 65
+},
+"45": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+186,
+100
+],
+"keyHash": [
+"1267650600228229401496703205376"
+],
+"keyName": "Play",
+"left": 15,
+"packetIndex": [
+56
+],
+"top": 0,
+"width": 65
+},
+"46": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+188,
+101
+],
+"keyHash": [
+"2535301200456458802993406410752"
+],
+"keyName": "Next",
+"left": 15,
+"packetIndex": [
+68
+],
+"top": 0,
+"width": 65
+}
+}
+},
+"2": {
+"keys": {
+"48": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+24,
+12
+],
+"keyHash": [
+"4096"
+],
+"keyName": "² ³",
+"left": 15,
+"packetIndex": [
+1
+],
+"top": 15,
+"width": 65
+},
+"49": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+26,
+13
+],
+"keyHash": [
+"8192"
+],
+"keyName": "& 1",
+"left": 15,
+"packetIndex": [
+13
+],
+"top": 15,
+"width": 65
+},
+"50": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+28,
+14
+],
+"keyHash": [
+"16384"
+],
+"keyName": "é 2",
+"left": 15,
+"packetIndex": [
+25
+],
+"top": 15,
+"width": 65
+},
+"51": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+30,
+15
+],
+"keyHash": [
+"32768"
+],
+"keyName": "\" 3",
+"left": 15,
+"packetIndex": [
+37
+],
+"top": 15,
+"width": 65
+},
+"52": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+32,
+16
+],
+"keyHash": [
+"65536"
+],
+"keyName": "' 4",
+"left": 15,
+"packetIndex": [
+49
+],
+"top": 15,
+"width": 65
+},
+"53": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+34,
+17
+],
+"keyHash": [
+"131072"
+],
+"keyName": "( 5",
+"left": 15,
+"packetIndex": [
+61
+],
+"top": 15,
+"width": 65
+},
+"54": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+36,
+18
+],
+"keyHash": [
+"262144"
+],
+"keyName": "- 6",
+"left": 15,
+"packetIndex": [
+73
+],
+"top": 15,
+"width": 65
+},
+"55": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+38,
+19
+],
+"keyHash": [
+"524288"
+],
+"keyName": "è 7",
+"left": 15,
+"packetIndex": [
+85
+],
+"top": 15,
+"width": 65
+},
+"56": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+40,
+20
+],
+"keyHash": [
+"1048576"
+],
+"keyName": "_ 8",
+"left": 15,
+"packetIndex": [
+97
+],
+"top": 15,
+"width": 65
+},
+"57": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+42,
+21
+],
+"keyHash": [
+"2097152"
+],
+"keyName": "ç 9",
+"left": 15,
+"packetIndex": [
+109
+],
+"top": 15,
+"width": 65
+},
+"58": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+44,
+22
+],
+"keyHash": [
+"4194304"
+],
+"keyName": "à 0",
+"left": 15,
+"packetIndex": [
+121
+],
+"top": 15,
+"width": 65
+},
+"59": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+46,
+23
+],
+"keyHash": [
+"8388608"
+],
+"keyName": ") °",
+"left": 15,
+"packetIndex": [
+133
+],
+"top": 15,
+"width": 65
+},
+"60": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+156,
+84
+],
+"keyHash": [
+"19342813113834066795298816"
+],
+"keyName": "= +",
+"left": 15,
+"packetIndex": [
+7
+],
+"top": 15,
+"width": 65
+},
+"61": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+158,
+86
+],
+"keyHash": [
+"77371252455336267181195264"
+],
+"keyName": "<---",
+"keySpace": "keyboard-key wide3",
+"left": 15,
+"packetIndex": [
+31
+],
+"top": 15,
+"width": 150
+},
+"62": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+144,
+76
+],
+"keyEmpty": [
+"keyboard-key-empty"
+],
+"keyHash": [
+"75557863725914323419136"
+],
+"keyName": "Ins",
+"left": 25,
+"packetIndex": [
+54
+],
+"top": 15,
+"width": 65
+},
+"63": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+146,
+77
+],
+"keyHash": [
+"151115727451828646838272"
+],
+"keyName": "Home",
+"left": 15,
+"packetIndex": [
+66
+],
+"top": 15,
+"width": 65
+},
+"64": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+148,
+78
+],
+"keyHash": [
+"302231454903657293676544"
+],
+"keyName": "PgUp",
+"left": 15,
+"packetIndex": [
+78
+],
+"top": 15,
+"width": 65
+},
+"65": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+190,
+102
+],
+"keyEmpty": [
+"keyboard-key-empty"
+],
+"keyHash": [
+"5070602400912917605986812821504"
+],
+"keyName": "Num",
+"left": 25,
+"packetIndex": [
+80
+],
+"top": 15,
+"width": 65
+},
+"66": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+192,
+103
+],
+"keyHash": [
+"10141204801825835211973625643008"
+],
+"keyName": "/",
+"left": 15,
+"packetIndex": [
+92
+],
+"top": 15,
+"width": 65
+},
+"67": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+194,
+104
+],
+"keyHash": [
+"20282409603651670423947251286016"
+],
+"keyName": "*",
+"left": 15,
+"packetIndex": [
+104
+],
+"top": 15,
+"width": 65
+},
+"68": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+196,
+105
+],
+"keyHash": [
+"40564819207303340847894502572032"
+],
+"keyName": "-",
+"left": 15,
+"packetIndex": [
+116
+],
+"top": 15,
+"width": 65
+}
+}
+},
+"3": {
+"keys": {
+"70": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+48,
+24
+],
+"keyHash": [
+"16777216"
+],
+"keyName": "Tab",
+"keySpace": "keyboard-key wide",
+"left": 15,
+"packetIndex": [
+2
+],
+"top": 15,
+"width": 108
+},
+"71": {
+"color": {
+"blue": 0,
+"green": 0,
+"red": 255
+},
+"default": true,
+"height": 70,
+"keyData": [
+50,
+25
+],
+"keyHash": [
+"33554432"
+],
+"keyName": "A",
+"left": 15,
+"packetIndex": [
+14
+],
+"top": 15,
+"width": 65
+},
+"72": {
+"color": {
+"blue": 0,
+"green": 0,
+"red": 255
+},
+"default": true,
+"height": 70,
+"keyData": [
+52,
+26
+],
+"keyHash": [
+"67108864"
+],
+"keyName": "Z",
+"left": 15,
+"packetIndex": [
+26
+],
+"top": 15,
+"width": 65
+},
+"73": {
+"color": {
+"blue": 0,
+"green": 0,
+"red": 255
+},
+"default": true,
+"height": 70,
+"keyData": [
+54,
+27
+],
+"keyHash": [
+"134217728"
+],
+"keyName": "E",
+"left": 15,
+"packetIndex": [
+38
+],
+"top": 15,
+"width": 65
+},
+"74": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+56,
+28
+],
+"keyHash": [
+"268435456"
+],
+"keyName": "R",
+"left": 15,
+"packetIndex": [
+50
+],
+"top": 15,
+"width": 65
+},
+"75": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+58,
+29
+],
+"keyHash": [
+"536870912"
+],
+"keyName": "T",
+"left": 15,
+"packetIndex": [
+62
+],
+"top": 15,
+"width": 65
+},
+"76": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+60,
+30
+],
+"keyHash": [
+"1073741824"
+],
+"keyName": "Y",
+"left": 15,
+"packetIndex": [
+74
+],
+"top": 15,
+"width": 65
+},
+"77": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+62,
+31
+],
+"keyHash": [
+"2147483648"
+],
+"keyName": "U",
+"left": 15,
+"packetIndex": [
+86
+],
+"top": 15,
+"width": 65
+},
+"78": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+64,
+32
+],
+"keyHash": [
+"4294967296"
+],
+"keyName": "I",
+"left": 15,
+"packetIndex": [
+98
+],
+"top": 15,
+"width": 65
+},
+"79": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+66,
+33
+],
+"keyHash": [
+"8589934592"
+],
+"keyName": "O",
+"left": 15,
+"packetIndex": [
+110
+],
+"top": 15,
+"width": 65
+},
+"80": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+68,
+34
+],
+"keyHash": [
+"17179869184"
+],
+"keyName": "P",
+"left": 15,
+"packetIndex": [
+122
+],
+"top": 15,
+"width": 65
+},
+"81": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+70,
+35
+],
+"keyHash": [
+"34359738368"
+],
+"keyName": "^ ¨",
+"left": 15,
+"packetIndex": [
+134
+],
+"top": 15,
+"width": 65
+},
+"82": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+150,
+79
+],
+"keyHash": [
+"604462909807314587353088"
+],
+"keyName": "$ £",
+"left": 15,
+"packetIndex": [
+90
+],
+"top": 15,
+"width": 65
+},
+"84": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+160,
+87
+],
+"keyEmpty": [
+"keyboard-key-empty",
+"keyboard-key-empty",
+"keyboard-key-empty"
+],
+"keyHash": [
+"154742504910672534362390528"
+],
+"keyName": "Del",
+"left": 25,
+"packetIndex": [
+43
+],
+"top": 15,
+"width": 65
+},
+"85": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+162,
+88
+],
+"keyHash": [
+"309485009821345068724781056"
+],
+"keyName": "End",
+"left": 15,
+"packetIndex": [
+55
+],
+"top": 15,
+"width": 65
+},
+"86": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+164,
+89
+],
+"keyHash": [
+"618970019642690137449562112"
+],
+"keyName": "PgDn",
+"left": 15,
+"packetIndex": [
+67
+],
+"top": 15,
+"width": 65
+},
+"87": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+202,
+108
+],
+"keyEmpty": [
+"keyboard-key-empty"
+],
+"keyHash": [
+"324518553658426726783156020576256"
+],
+"keyName": "7",
+"left": 25,
+"packetIndex": [
+9
+],
+"top": 15,
+"width": 65
+},
+"88": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+204,
+109
+],
+"keyHash": [
+"649037107316853453566312041152512"
+],
+"keyName": "8",
+"left": 15,
+"packetIndex": [
+21
+],
+"top": 15,
+"width": 65
+},
+"89": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+206,
+110
+],
+"keyHash": [
+"1298074214633706907132624082305024"
+],
+"keyName": "9",
+"left": 15,
+"packetIndex": [
+33
+],
+"top": 15,
+"width": 65
+},
+"90": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 155,
+"keyData": [
+198,
+106
+],
+"keyHash": [
+"81129638414606681695789005144064"
+],
+"keyName": "+",
+"keySpace": "keyboard-key-125",
+"left": 15,
+"packetIndex": [
+128
+],
+"top": 15,
+"width": 65
+}
+},
+"top": 65
+},
+"4": {
+"css": "keyboard-row-25",
+"keys": {
+"92": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+72,
+36
+],
+"keyHash": [
+"68719476736"
+],
+"keyName": "CAPS",
+"keySpace": "keyboard-key wide",
+"left": 15,
+"packetIndex": [
+3
+],
+"top": 15,
+"width": 131
+},
+"93": {
+"color": {
+"blue": 0,
+"green": 0,
+"red": 255
+},
+"default": true,
+"height": 70,
+"keyData": [
+74,
+37
+],
+"keyHash": [
+"137438953472"
+],
+"keyName": "Q",
+"left": 15,
+"packetIndex": [
+15
+],
+"top": 15,
+"width": 65
+},
+"94": {
+"color": {
+"blue": 0,
+"green": 0,
+"red": 255
+},
+"default": true,
+"height": 70,
+"keyData": [
+76,
+38
+],
+"keyHash": [
+"274877906944"
+],
+"keyName": "S",
+"left": 15,
+"packetIndex": [
+27
+],
+"top": 15,
+"width": 65
+},
+"95": {
+"color": {
+"blue": 0,
+"green": 0,
+"red": 255
+},
+"default": true,
+"height": 70,
+"keyData": [
+78,
+39
+],
+"keyHash": [
+"549755813888"
+],
+"keyName": "D",
+"left": 15,
+"packetIndex": [
+39
+],
+"top": 15,
+"width": 65
+},
+"96": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+80,
+40
+],
+"keyHash": [
+"1099511627776"
+],
+"keyName": "F",
+"left": 15,
+"packetIndex": [
+51
+],
+"top": 15,
+"width": 65
+},
+"97": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+82,
+41
+],
+"keyHash": [
+"2199023255552"
+],
+"keyName": "G",
+"left": 15,
+"packetIndex": [
+63
+],
+"top": 15,
+"width": 65
+},
+"98": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+84,
+42
+],
+"keyHash": [
+"4398046511104"
+],
+"keyName": "H",
+"left": 15,
+"packetIndex": [
+75
+],
+"top": 15,
+"width": 65
+},
+"99": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+86,
+43
+],
+"keyHash": [
+"8796093022208"
+],
+"keyName": "J",
+"left": 15,
+"packetIndex": [
+87
+],
+"top": 15,
+"width": 65
+},
+"100": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+88,
+44
+],
+"keyHash": [
+"17592186044416"
+],
+"keyName": "K",
+"left": 15,
+"packetIndex": [
+99
+],
+"top": 15,
+"width": 65
+},
+"101": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+90,
+45
+],
+"keyHash": [
+"35184372088832"
+],
+"keyName": "L",
+"left": 15,
+"packetIndex": [
+111
+],
+"top": 15,
+"width": 65
+},
+"102": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+92,
+46
+],
+"keyHash": [
+"70368744177664"
+],
+"keyName": "M",
+"left": 15,
+"packetIndex": [
+123
+],
+"top": 15,
+"width": 65
+},
+"103": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+94,
+47
+],
+"keyHash": [
+"140737488355328"
+],
+"keyName": "ù %",
+"left": 15,
+"packetIndex": [
+135
+],
+"top": 15,
+"width": 65
+},
+"104": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+162,
+81
+],
+"keyHash": [
+"2417851639229258349412352"
+],
+"keyName": "* µ",
+"left": 15,
+"packetIndex": [
+114
+],
+"top": 15,
+"width": 107
+},
+"105": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"css": "enter-custom",
+"default": true,
+"height": 155,
+"keyData": [
+154,
+82
+],
+"keyHash": [
+"4835703278458516698824704"
+],
+"keyName": "Enter",
+"keySpace": "keyboard-key wide",
+"left": 15,
+"packetIndex": [
+126
+],
+"top": 15,
+"width": 164
+},
+"106": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+208,
+112
+],
+"keyEmpty": [
+"keyboard-key-empty",
+"keyboard-key-empty",
+"keyboard-key-empty",
+"keyboard-key-empty",
+"keyboard-key-empty"
+],
+"keyHash": [
+"5192296858534827628530496329220096"
+],
+"keyName": "4",
+"left": 275,
+"packetIndex": [
+57
+],
+"top": 15,
+"width": 65
+},
+"107": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+210,
+113
+],
+"keyHash": [
+"10384593717069655257060992658440192"
+],
+"keyName": "5",
+"left": 15,
+"packetIndex": [
+69
+],
+"top": 15,
+"width": 65
+},
+"108": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+212,
+114
+],
+"keyHash": [
+"20769187434139310514121985316880384"
+],
+"keyName": "6",
+"left": 15,
+"packetIndex": [
+81
+],
+"top": 15,
+"width": 65
+}
+}
+},
+"5": {
+"keys": {
+"109": {
+"color": {
+"blue": 0,
+"green": 255,
+"red": 255
+},
+"default": true,
+"height": 70,
+"keyData": [
+96,
+48
+],
+"keyHash": [
+"281474976710656"
+],
+"keyName": "Shift",
+"keySpace": "keyboard-key wide",
+"left": 15,
+"packetIndex": [
+4
+],
+"top": 15,
+"width": 170
+},
+"110": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+98,
+49
+],
+"keyHash": [
+"562949953421312"
+],
+"keyName": "< >",
+"left": 15,
+"packetIndex": [
+16
+],
+"top": 15,
+"width": 65
+},
+"111": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+100,
+50
+],
+"keyHash": [
+"1125899906842624"
+],
+"keyName": "W",
+"left": 15,
+"packetIndex": [
+28
+],
+"top": 15,
+"width": 65
+},
+"112": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+100,
+51
+],
+"keyHash": [
+"2251799813685248"
+],
+"keyName": "X",
+"left": 15,
+"packetIndex": [
+40
+],
+"top": 15,
+"width": 65
+},
+"113": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+102,
+52
+],
+"keyHash": [
+"4503599627370496"
+],
+"keyName": "C",
+"left": 15,
+"packetIndex": [
+52
+],
+"top": 15,
+"width": 65
+},
+"114": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+104,
+53
+],
+"keyHash": [
+"9007199254740992"
+],
+"keyName": "V",
+"left": 15,
+"packetIndex": [
+64
+],
+"top": 15,
+"width": 65
+},
+"115": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+106,
+54
+],
+"keyHash": [
+"18014398509481984"
+],
+"keyName": "B",
+"left": 15,
+"packetIndex": [
+76
+],
+"top": 15,
+"width": 65
+},
+"116": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+108,
+55
+],
+"keyHash": [
+"36028797018963968"
+],
+"keyName": "N",
+"left": 15,
+"packetIndex": [
+88
+],
+"top": 15,
+"width": 65
+},
+"117": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+110,
+56
+],
+"keyHash": [
+"72057594037927936"
+],
+"keyName": ", ?",
+"left": 15,
+"packetIndex": [
+100
+],
+"top": 15,
+"width": 65
+},
+"118": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+112,
+57
+],
+"keyHash": [
+"144115188075855872"
+],
+"keyName": "; .",
+"left": 15,
+"packetIndex": [
+112
+],
+"top": 15,
+"width": 65
+},
+"119": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+114,
+58
+],
+"keyHash": [
+"288230376151711744"
+],
+"keyName": ": /",
+"left": 15,
+"packetIndex": [
+124
+],
+"top": 15,
+"width": 65
+},
+"120": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+116,
+59
+],
+"keyHash": [
+"576460752303423488"
+],
+"keyName": "! §",
+"left": 15,
+"packetIndex": [
+136
+],
+"top": 15,
+"width": 65
+},
+"121": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+166,
+90
+],
+"keyHash": [
+"1237940039285380274899124224"
+],
+"keyName": "Shift",
+"keySpace": "keyboard-key wide3",
+"left": 15,
+"packetIndex": [
+79
+],
+"top": 15,
+"width": 205
+},
+"122": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+170,
+92
+],
+"keyEmpty": [
+"keyboard-key-empty",
+"keyboard-key-empty"
+],
+"keyHash": [
+"4951760157141521099596496896"
+],
+"keyName": "↑",
+"left": 105,
+"packetIndex": [
+103
+],
+"top": 15,
+"width": 65
+},
+"123": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+214,
+115
+],
+"keyEmpty": [
+"keyboard-key-empty",
+"keyboard-key-empty"
+],
+"keyHash": [
+"41538374868278621028243970633760768"
+],
+"keyName": "1",
+"left": 105,
+"packetIndex": [
+93
+],
+"top": 15,
+"width": 65
+},
+"124": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+216,
+116
+],
+"keyHash": [
+"83076749736557242056487941267521536"
+],
+"keyName": "2",
+"left": 15,
+"packetIndex": [
+105
+],
+"top": 15,
+"width": 65
+},
+"125": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+218,
+117
+],
+"keyHash": [
+"166153499473114484112975882535043072"
+],
+"keyName": "3",
+"left": 15,
+"packetIndex": [
+117
+],
+"top": 15,
+"width": 65
+},
+"126": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 155,
+"keyData": [
+200,
+107
+],
+"keyHash": [
+"162259276829213363391578010288128"
+],
+"keyName": "Enter",
+"keySpace": "keyboard-key-125",
+"left": 15,
+"packetIndex": [
+140
+],
+"top": 15,
+"width": 65
+}
+},
+"top": 65
+},
+"6": {
+"keys": {
+"127": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+118,
+60
+],
+"keyHash": [
+"1152921504606846976"
+],
+"keyName": "Ctrl",
+"keySpace": "keyboard-key wide",
+"left": 15,
+"packetIndex": [
+5
+],
+"top": 15,
+"width": 90
+},
+"128": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+120,
+61
+],
+"keyHash": [
+"2305843009213693952"
+],
+"keyName": "Win",
+"left": 15,
+"packetIndex": [
+17
+],
+"top": 15,
+"width": 90
+},
+"129": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+122,
+62
+],
+"keyHash": [
+"4611686018427387904"
+],
+"keyName": "Alt",
+"keySpace": "keyboard-key wide",
+"left": 15,
+"packetIndex": [
+29
+],
+"top": 15,
+"width": 90
+},
+"130": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+124,
+64
+],
+"keyHash": [
+"18446744073709551616"
+],
+"keyName": "----------",
+"keySpace": "keyboard-key wide6",
+"left": 15,
+"packetIndex": [
+53
+],
+"top": 15,
+"width": 151
+},
+"131": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+126,
+67
+],
+"keyHash": [
+"147573952589676412928"
+],
+"keyName": "AltGr",
+"left": 15,
+"packetIndex": [
+89
+],
+"top": 15,
+"width": 90
+},
+"132": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+128,
+68
+],
+"keyHash": [
+"295147905179352825856"
+],
+"keyName": "Win",
+"left": 15,
+"packetIndex": [
+101
+],
+"top": 15,
+"width": 90
+},
+"133": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+130,
+69
+],
+"keyHash": [
+"590295810358705651712"
+],
+"keyName": "Menu",
+"left": 15,
+"packetIndex": [
+113
+],
+"top": 15,
+"width": 90
+},
+"134": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+168,
+91
+],
+"keyHash": [
+"2475880078570760549798248448"
+],
+"keyName": "Ctrl",
+"keySpace": "keyboard-key wide",
+"left": 15,
+"packetIndex": [
+91
+],
+"top": 15,
+"width": 90
+},
+"135": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+172,
+93
+],
+"keyEmpty": [
+"keyboard-key-empty"
+],
+"keyHash": [
+"9903520314283042199192993792"
+],
+"keyName": "←",
+"left": 25,
+"packetIndex": [
+115
+],
+"top": 15,
+"width": 65
+},
+"136": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+174,
+94
+],
+"keyHash": [
+"19807040628566084398385987584"
+],
+"keyName": "↓",
+"left": 15,
+"packetIndex": [
+127
+],
+"top": 15,
+"width": 65
+},
+"137": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+176,
+95
+],
+"keyHash": [
+"39614081257132168796771975168"
+],
+"keyName": "→",
+"left": 15,
+"packetIndex": [
+139
+],
+"top": 15,
+"width": 65
+},
+"138": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+220,
+118
+],
+"keyEmpty": [
+"keyboard-key-empty"
+],
+"keyHash": [
+"332306998946228968225951765070086144"
+],
+"keyName": "0",
+"keySpace": "keyboard-key wide",
+"left": 25,
+"packetIndex": [
+129
+],
+"top": 15,
+"width": 145
+},
+"139": {
+"color": {
+"blue": 255,
+"green": 255,
+"red": 0
+},
+"default": true,
+"height": 70,
+"keyData": [
+222,
+119
+],
+"keyHash": [
+"664613997892457936451903530140172288"
+],
+"keyName": ".",
+"left": 15,
+"packetIndex": [
+141
+],
+"top": 15,
+"width": 65
+}
+}
+}
+},
+"rows": 6,
+"uppercaseClass": "key-uppercase",
+"version": 2
+}


### PR DESCRIPTION
## Description
Adds French (AZERTY) keyboard layout profile for the Corsair K70 RGB MK2.

## Changes
- Added `database/keyboard/k70mk2-fr.json`

## Layout details
- Based on the existing DE (QWERTZ) layout
- Adapted all key names to match the French AZERTY standard (ISO FR)
- Key changes:
  - Row 2: digits replaced by accented chars (é, è, à, ç, ù) as primary + digits as shifted
  - Row 3 (Tab): Q→A, W→Z, [ {→^ ¨, ] }→$ £
  - Row 4 (Caps): A→Q, ; :→M, ' "→ù %, \ |→* µ
  - Row 5 (Shift): Y→W, M→, ?, , <→; ., . >→: /, / ?→! §
  - Row 6: Alt→AltGr
- Fixed keyData conflict on W key ([98,50]→[100,50]) to ensure static RGB works correctly