### PR TITLE
add French (AZERTY) keyboard layout for K70 Core RGB

### DIFF
--- a/database/keyboard/k70core-fr.json
+++ b/database/keyboard/k70core-fr.json
@@ -1,0 +1,1977 @@
+{
+  "version": 2,
+  "uppercaseClass": "key-uppercase",
+  "fontSize": 14,
+  "key": "k70core-default",
+  "device": "K70 Core RGB",
+  "layout": "FR",
+  "rows": 6,
+  "modifierPosition": 15,
+  "row": {
+    "0": {
+      "keys": {
+        "1": {
+          "keyName": "ESC",
+          "width": 65,
+          "height": 70,
+          "left": 0,
+          "top": 0,
+          "packetIndex": [123],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 0
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [41, 57, 56],
+          "keyHash": ["2199023255552"]
+        },
+        "2": {
+          "keyName": "F1",
+          "width": 65,
+          "height": 70,
+          "left": 95,
+          "top": 0,
+          "packetIndex": [174],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyEmpty": ["keyboard-key-empty"],
+          "keyData": [58, 57, 56],
+          "keyHash": ["288230376151711744"],
+          "isLock": true
+
+        },
+        "3": {
+          "keyName": "F2",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [177],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [59, 57, 56],
+          "keyHash": ["576460752303423488"]
+        },
+        "4": {
+          "keyName": "F3",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [180],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [60, 57, 56],
+          "actionType": 12,
+          "keyHash": ["1152921504606846976"]
+        },
+        "5": {
+          "keyName": "F4",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [183],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [61, 57, 56],
+          "actionType": 11,
+          "keyHash": ["2305843009213693952"]
+        },
+        "6": {
+          "keyName": "F5",
+          "width": 65,
+          "height": 70,
+          "left": 55,
+          "top": 0,
+          "packetIndex": [186],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyEmpty": ["keyboard-key-empty"],
+          "default": true,
+          "keyData": [62, 57, 56],
+          "keyHash": ["4611686018427387904"],
+          "fnActionType": 1,
+          "fnActionCommand": 4,
+          "mediaKey": true
+        },
+        "7": {
+          "keyName": "F6",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [189],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [63, 57, 56],
+          "keyHash": ["9223372036854775808"],
+          "fnActionType": 1,
+          "fnActionCommand": 5,
+          "mediaKey": true
+        },
+        "8": {
+          "keyName": "F7",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [192],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [64, 57, 56],
+          "keyHash": ["18446744073709551616"],
+          "fnActionType": 1,
+          "fnActionCommand": 6,
+          "mediaKey": true
+        },
+        "9": {
+          "keyName": "F8",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [195],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [65, 57, 56],
+          "keyHash": ["36893488147419103232"],
+          "fnActionType": 1,
+          "fnActionCommand": 7,
+          "mediaKey": true
+        },
+        "10": {
+          "keyName": "F9",
+          "width": 65,
+          "height": 70,
+          "left": 60,
+          "top": 0,
+          "packetIndex": [198],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyEmpty": ["keyboard-key-empty"],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [66, 57, 56],
+          "keyHash": ["73786976294838206464"]
+        },
+        "11": {
+          "keyName": "F10",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [201],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [67, 57, 56],
+          "keyHash": ["147573952589676412928"]
+        },
+        "12": {
+          "keyName": "F11",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [204],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [68, 57, 56],
+          "keyHash": ["295147905179352825856"]
+        },
+        "13": {
+          "keyName": "F12",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [207],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [69, 57, 56],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "keyHash": ["590295810358705651712"]
+        },
+        "14": {
+          "keyName": "PrtSc",
+          "width": 65,
+          "height": 70,
+          "left": 25,
+          "top": 0,
+          "packetIndex": [210],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyEmpty": ["keyboard-key-empty"],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [70, 57, 56],
+          "keyHash": ["1180591620717411303424"]
+        },
+        "15": {
+          "keyName": "ScrLk",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [213],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [71, 57, 56],
+          "keyHash": ["2361183241434822606848"]
+        },
+        "16": {
+          "keyName": "Pause",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [216],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [72, 57, 56],
+          "keyHash": ["4722366482869645213696"]
+        },
+        "17": {
+          "keyName": "iCUE",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [216],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyEmpty": ["keyboard-key-empty"],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": false,
+          "keyData": [124, 57, 56],
+          "actionType": 1,
+          "actionCommand": 3,
+          "keyHash": ["21267647932558653966460912964485513216"]
+        }
+      }
+    },
+    "1": {
+      "keys": {
+        "18": {
+          "keyName": "²",
+          "width": 65,
+          "height": 70,
+          "left": 0,
+          "top": 15,
+          "packetIndex": [159],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [53, 57, 56],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "keyHash": ["9007199254740992"]
+        },
+        "19": {
+          "keyName": "1 &",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [90],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [30, 57, 56],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "keyHash": ["1073741824"]
+        },
+        "20": {
+          "keyName": "2 é ~",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [93],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [31, 57, 56],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "keyHash": ["2147483648"]
+        },
+        "21": {
+          "keyName": "3 # \"",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [96],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [32, 57, 56],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "keyHash": ["4294967296"]
+        },
+        "22": {
+          "keyName": "4 ' {",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [99],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [33, 57, 56],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "keyHash": ["8589934592"]
+        },
+        "23": {
+          "keyName": "5 ( [",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [102],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [34, 57, 56],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "keyHash": ["17179869184"]
+        },
+        "24": {
+          "keyName": "6 - |",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [105],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [35, 57, 56],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "keyHash": ["34359738368"]
+        },
+        "25": {
+          "keyName": "7 è `",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [108],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [36, 57, 56],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "keyHash": ["68719476736"]
+        },
+        "26": {
+          "keyName": "8 _ \\",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [111],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [37, 57, 56],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "keyHash": ["137438953472"]
+        },
+        "27": {
+          "keyName": "9 ç ^",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [114],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [38, 57, 56],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "keyHash": ["274877906944"]
+        },
+        "28": {
+          "keyName": "0 à @",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [117],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [39, 57, 56],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "keyHash": ["549755813888"]
+        },
+        "29": {
+          "keyName": "° ) ]",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [135],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [45, 57, 56],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "keyHash": ["35184372088832"]
+        },
+        "30": {
+          "keyName": "+ = }",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [138],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [46, 57, 56],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "keyHash": ["70368744177664"]
+        },
+        "31": {
+          "keyName": "<---",
+          "width": 150,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [126],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keySpace": "keyboard-key wide3",
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [42, 57, 56],
+          "keyHash": ["4398046511104"]
+        },
+        "32": {
+          "keyName": "Ins",
+          "width": 65,
+          "height": 70,
+          "left": 25,
+          "top": 15,
+          "packetIndex": [219],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyEmpty": ["keyboard-key-empty"],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [73, 57, 56],
+          "keyHash": ["9444732965739290427392"]
+        },
+        "33": {
+          "keyName": "Home",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [222],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [74, 57, 56],
+          "keyHash": ["18889465931478580854784"]
+        },
+        "34": {
+          "keyName": "PgUp",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [225],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [75, 57, 56],
+          "keyHash": ["37778931862957161709568"]
+        },
+        "35": {
+          "keyName": "Num",
+          "width": 65,
+          "height": 70,
+          "left": 25,
+          "top": 15,
+          "packetIndex": [249],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyEmpty": ["keyboard-key-empty"],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [83, 57, 56],
+          "keyHash": ["9671406556917033397649408"]
+        },
+        "36": {
+          "keyName": "/",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [252],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [84, 57, 56],
+          "keyHash": ["19342813113834066795298816"]
+        },
+        "37": {
+          "keyName": "*",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [255],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [85, 57, 56],
+          "keyHash": ["38685626227668133590597632"]
+        },
+        "38": {
+          "keyName": "-",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [258],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [86, 57, 56],
+          "keyHash": ["77371252455336267181195264"]
+        }
+      }
+    },
+    "2": {
+      "top": 65,
+      "keys": {
+        "39": {
+          "keyName": "Tab",
+          "width": 108,
+          "height": 70,
+          "left": 0,
+          "top": 15,
+          "packetIndex": [129],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keySpace": "keyboard-key wide",
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [43, 57, 56],
+          "keyHash": ["8796093022208"]
+        },
+        "40": {
+          "keyName": "A",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [60],
+          "color": {
+            "red": 255,
+            "green": 0,
+            "blue": 0
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [20, 57, 56],
+          "keyHash": ["1048576"]
+        },
+        "41": {
+          "keyName": "Z",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [78],
+          "color": {
+            "red": 255,
+            "green": 0,
+            "blue": 0
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [26, 57, 56],
+          "keyHash": ["67108864"]
+        },
+        "42": {
+          "keyName": "E €",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [24],
+          "color": {
+            "red": 255,
+            "green": 0,
+            "blue": 0
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [8, 57, 56],
+          "keyHash": ["256"]
+        },
+        "43": {
+          "keyName": "R",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [63],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [21, 57, 56],
+          "keyHash": ["2097152"]
+        },
+        "44": {
+          "keyName": "T",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [69],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [23, 57, 56],
+          "keyHash": ["8388608"]
+        },
+        "45": {
+          "keyName": "Y",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [84],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [28, 57, 56],
+          "keyHash": ["268435456"]
+        },
+        "46": {
+          "keyName": "U",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [72],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [24, 57, 56],
+          "keyHash": ["16777216"]
+        },
+        "47": {
+          "keyName": "I",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [36],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [12, 57, 56],
+          "keyHash": ["4096"]
+        },
+        "48": {
+          "keyName": "O",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [54],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [18, 57, 56],
+          "keyHash": ["262144"]
+        },
+        "49": {
+          "keyName": "P",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [57],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [19, 57, 56],
+          "keyHash": ["524288"]
+        },
+        "50": {
+          "keyName": "¨ ^",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [141],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [47, 57, 56],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "keyHash": ["140737488355328"]
+        },
+        "51": {
+          "keyName": "$ £ ¤",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [144],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [48, 57, 56],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "keyHash": ["281474976710656"]
+        },
+        "53": {
+          "keyName": "Del",
+          "width": 65,
+          "height": 70,
+          "left": 25,
+          "top": 15,
+          "packetIndex": [228],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyEmpty": ["keyboard-key-empty", "keyboard-key-empty", "keyboard-key-empty"],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [76, 57, 56],
+          "keyHash": ["75557863725914323419136"]
+        },
+        "54": {
+          "keyName": "End",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [231],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [77, 57, 56],
+          "keyHash": ["151115727451828646838272"]
+        },
+        "55": {
+          "keyName": "PgDn",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [234],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [78, 57, 56],
+          "keyHash": ["302231454903657293676544"]
+        },
+        "56": {
+          "keyName": "7",
+          "width": 65,
+          "height": 70,
+          "left": 25,
+          "top": 15,
+          "packetIndex": [285],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyEmpty": ["keyboard-key-empty"],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [95, 57, 56],
+          "keyHash": ["39614081257132168796771975168"]
+        },
+        "57": {
+          "keyName": "8",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [288],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [96, 57, 56],
+          "keyHash": ["79228162514264337593543950336"]
+        },
+        "58": {
+          "keyName": "9",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [291],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [97, 57, 56],
+          "keyHash": ["158456325028528675187087900672"]
+        },
+        "59": {
+          "keyName": "+",
+          "width": 65,
+          "height": 155,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [261],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keySpace": "keyboard-key-125",
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [87, 57, 56],
+          "keyHash": ["154742504910672534362390528"]
+        }
+      }
+    },
+    "3": {
+      "css": "keyboard-row-24",
+      "keys": {
+        "30": {
+          "keyName": "CAPS",
+          "width": 131,
+          "height": 70,
+          "left": 0,
+          "top": 15,
+          "packetIndex": [171],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keySpace": "keyboard-key wide",
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [57, 57, 56],
+          "keyHash": ["144115188075855872"]
+        },
+        "60": {
+          "keyName": "Q",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [12],
+          "color": {
+            "red": 255,
+            "green": 0,
+            "blue": 0
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [4, 57, 56],
+          "keyHash": ["16"]
+        },
+        "61": {
+          "keyName": "S",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [66],
+          "color": {
+            "red": 255,
+            "green": 0,
+            "blue": 0
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [22, 57, 56],
+          "keyHash": ["4194304"]
+        },
+        "62": {
+          "keyName": "D",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [21],
+          "color": {
+            "red": 255,
+            "green": 0,
+            "blue": 0
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [7, 57, 56],
+          "keyHash": ["128"]
+        },
+        "63": {
+          "keyName": "F",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [27],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [9, 57, 56],
+          "keyHash": ["512"]
+        },
+        "64": {
+          "keyName": "G",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [30],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [10, 57, 56],
+          "keyHash": ["1024"]
+        },
+        "65": {
+          "keyName": "H",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [33],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [11, 57, 56],
+          "keyHash": ["2048"]
+        },
+        "66": {
+          "keyName": "J",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [39],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [13, 57, 56],
+          "keyHash": ["8192"]
+        },
+        "67": {
+          "keyName": "K",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [42],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [14, 57, 56],
+          "keyHash": ["16384"]
+        },
+        "68": {
+          "keyName": "L",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [45],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [15, 57, 56],
+          "keyHash": ["32768"]
+        },
+        "69": {
+          "keyName": "M",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [153],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [51, 57, 56],
+          "keyHash": ["2251799813685248"]
+        },
+        "70": {
+          "keyName": "ù %",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [156],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [52, 57, 56],
+          "keyHash": ["4503599627370496"]
+        },
+        "71": {
+          "keyName": "* µ",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [150],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [50, 57, 56],
+          "keyHash": ["1125899906842624"]
+        },
+        "72": {
+          "keyName": "Enter",
+          "width": 108,
+          "height": 155,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [120],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keySpace": "keyboard-key wide",
+          "css": "enter-custom",
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [40, 57, 56],
+          "keyHash": ["1099511627776"]
+        },
+        "73": {
+          "keyName": "4",
+          "width": 65,
+          "height": 70,
+          "left": 275,
+          "top": 15,
+          "packetIndex": [276],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyEmpty": ["keyboard-key-empty","keyboard-key-empty","keyboard-key-empty","keyboard-key-empty","keyboard-key-empty"],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [92, 57, 56],
+          "keyHash": ["4951760157141521099596496896"]
+        },
+        "74": {
+          "keyName": "5",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [279],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [93, 57, 56],
+          "keyHash": ["9903520314283042199192993792"]
+        },
+        "75": {
+          "keyName": "6",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [282],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [94, 57, 56],
+          "keyHash": ["19807040628566084398385987584"]
+        }
+      }
+    },
+    "4": {
+      "top": 65,
+      "keys": {
+        "76": {
+          "keyName": "Shift",
+          "width": 108,
+          "height": 70,
+          "left": 0,
+          "top": 15,
+          "packetIndex": [318],
+          "color": {
+            "red": 255,
+            "green": 255,
+            "blue": 0
+          },
+          "keySpace": "keyboard-key wide",
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [106, 63, 62],
+          "keyHash": ["81129638414606681695789005144064"]
+        },
+        "77": {
+          "keyName": "< >",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [300],
+          "keyData": [100, 57, 56],
+          "default": true,
+          "keyHash": ["1267650600228229401496703205376"],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          }
+        },
+        "78": {
+          "keyName": "W",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [87],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [29, 57, 56],
+          "keyHash": ["536870912"]
+        },
+        "79": {
+          "keyName": "X",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [81],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [27, 57, 56],
+          "keyHash": ["134217728"]
+        },
+        "80": {
+          "keyName": "C",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [18],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [6, 57, 56],
+          "keyHash": ["64"]
+        },
+        "81": {
+          "keyName": "V",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [75],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [25, 57, 56],
+          "keyHash": ["33554432"]
+        },
+        "82": {
+          "keyName": "B",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [15],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [5, 57, 56],
+          "keyHash": ["32"]
+        },
+        "83": {
+          "keyName": "N",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [51],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [17, 57, 56],
+          "keyHash": ["131072"]
+        },
+        "84": {
+          "keyName": ", ?",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [48],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [16, 57, 56],
+          "keyHash": ["65536"]
+        },
+        "85": {
+          "keyName": "; .",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [162],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [54, 57, 56],
+          "keyHash": ["18014398509481984"]
+        },
+        "86": {
+          "keyName": ": /",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [165],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [55, 57, 56],
+          "keyHash": ["36028797018963968"]
+        },
+        "87": {
+          "keyName": "! §",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [168],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [56, 57, 56],
+          "keyHash": ["72057594037927936"]
+        },
+        "88": {
+          "keyName": "Shift",
+          "width": 205,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [330],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keySpace": "keyboard-key wide3",
+          "default": true,
+          "keyData": [110, 63, 62],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "keyHash": ["1298074214633706907132624082305024"]
+        },
+        "106": {
+          "keyName": "↑",
+          "width": 65,
+          "height": 70,
+          "left": 105,
+          "top": 15,
+          "packetIndex": [246],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyEmpty": ["keyboard-key-empty", "keyboard-key-empty"],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [82, 57, 56],
+          "keyHash": ["4835703278458516698824704"]
+        },
+        "107": {
+          "keyName": "1",
+          "width": 65,
+          "height": 70,
+          "left": 105,
+          "top": 15,
+          "packetIndex": [267],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyEmpty": ["keyboard-key-empty", "keyboard-key-empty"],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [89, 57, 56],
+          "keyHash": ["618970019642690137449562112"]
+        },
+        "108": {
+          "keyName": "2",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [270],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [90, 57, 56],
+          "keyHash": ["1237940039285380274899124224"]
+        },
+        "109": {
+          "keyName": "3",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [273],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [91, 57, 56],
+          "keyHash": ["2475880078570760549798248448"]
+        },
+        "110": {
+          "keyName": "Enter",
+          "width": 65,
+          "height": 155,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [264],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keySpace": "keyboard-key-125",
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [88, 57, 56],
+          "keyHash": ["309485009821345068724781056"]
+        }
+      }
+    },
+    "5": {
+      "keys": {
+        "93": {
+          "keyName": "Ctrl",
+          "width": 90,
+          "height": 70,
+          "left": 0,
+          "top": 15,
+          "packetIndex": [315],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keySpace": "keyboard-key wide",
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [105, 63, 62],
+          "keyHash": ["40564819207303340847894502572032"]
+        },
+        "94": {
+          "keyName": "Win",
+          "width": 90,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [324],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "default": true,
+          "keyData": [108, 57, 56],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "keyHash": ["324518553658426726783156020576256"]
+        },
+        "95": {
+          "keyName": "Alt",
+          "width": 90,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [321],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keySpace": "keyboard-key wide",
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [107, 63, 62],
+          "keyHash": ["162259276829213363391578010288128"]
+        },
+        "96": {
+          "keyName": "----------",
+          "width": 455,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [132],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keySpace": "keyboard-key wide7",
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [44, 57, 56],
+          "keyHash": ["17592186044416"]
+        },
+        "97": {
+          "keyName": "Alt",
+          "width": 90,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [333],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [111, 63, 62],
+          "keyHash": ["2596148429267413814265248164610048"]
+        },
+        "98": {
+          "keyName": "Fn",
+          "width": 90,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [366],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "onlyColor": true,
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "functionKey": true,
+          "modifier": true,
+          "keyData": [122, 63, 62],
+          "keyHash": [""]
+        },
+        "99": {
+          "keyName": "Menu",
+          "width": 90,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [303],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [101, 57, 56],
+          "keyHash": ["2535301200456458802993406410752"]
+        },
+        "100": {
+          "keyName": "Ctrl",
+          "width": 90,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [327],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [109, 63, 62],
+          "keyHash": ["649037107316853453566312041152512"]
+        },
+        "101": {
+          "keyName": "←",
+          "width": 65,
+          "height": 70,
+          "left": 25,
+          "top": 15,
+          "packetIndex": [240],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyEmpty": ["keyboard-key-empty"],
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [80, 57, 56],
+          "keyHash": ["1208925819614629174706176"]
+        },
+        "102": {
+          "keyName": "↓",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [243],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [81, 57, 56],
+          "keyHash": ["2417851639229258349412352"]
+        },
+        "103": {
+          "keyName": "→",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [237],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [79, 57, 56],
+          "keyHash": ["604462909807314587353088"]
+        },
+        "104": {
+          "keyName": "0",
+          "width": 145,
+          "height": 70,
+          "left": 25,
+          "top": 15,
+          "packetIndex": [294],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyEmpty": ["keyboard-key-empty"],
+          "keySpace": "keyboard-key wide",
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [98, 57, 56],
+          "keyHash": ["316912650057057350374175801344"]
+        },
+        "105": {
+          "keyName": ".",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [297],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "colorOffOnFunctionKey": true,
+          "colorOffOnFunctionKeyInternal": true,
+          "default": true,
+          "keyData": [99, 57, 56],
+          "keyHash": ["633825300114114700748351602688"]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `database/keyboard/k70core-fr.json`: a complete FR/AZERTY layout for the Corsair K70 Core RGB keyboard, based on the existing `k70core.json` (US/QWERTY)
- This is a JSON-only change — no Go code modifications required, as the keyboard loading system auto-discovers layout files

## Layout changes from US

| Area | US (QWERTY) | FR (AZERTY) |
|---|---|---|
| Number row | `` ` ~ `` `1`…`=` | `²` `1 &`…`+ = }` with AltGr variants (é, è, à, ù, ç…) |
| QWERTY row | `Q W E [ ] \ |` | `A Z E € ¨ ^ $ £ ¤` — `\ |` removed, `Del` shifted left |
| Home row | `A S … L ; : ' ''` | `Q` (ISO key) `S … M ù % * µ` |
| Bottom row | `Shift Z X … / ? Shift` | `Shift < >` (ISO key) `W X … ! § Shift` |
| Enter | Wide ANSI (width 164) | Tall ISO (width 108, height 155) |
| Left Shift | Wide (width 170) | Narrow (width 108) for ISO extra key |

## Verification

- `packetIndex` and `keyData` values for the two ISO extra keys (`Q` at `[12]` and `< >` at `[300]`) are validated against the existing `k70coretklW-de.json` German ISO layout which uses the same hardware positions
- All key IDs are unique (no new duplicates beyond those already present in `k70core.json`)
- JSON validated and key count confirmed: 106 keys (105 US + 2 ISO extra keys − 1 ANSI-only `\ |` key)

## Testing

I have a K70 Core RGB keyboard but it is not yet connected to test the layout live. I am looking for feedback on whether the ISO key positions and `packetIndex` values are correct before doing a full hardware test.