### PR TITLE
Add ENE SMBus memory support

### DIFF
--- a/src/audio/audio.go
+++ b/src/audio/audio.go
@@ -272,7 +272,7 @@ func setAudioConfig(frames, rate, channels, pollingRate, debug uint32) error {
 	}
 
 	if msg, ok := audioErrors[rc]; ok {
-		return fmt.Errorf(msg)
+		return fmt.Errorf("%s", msg)
 	}
 
 	return fmt.Errorf("audio engine error (%d)", rc)

--- a/src/devices/memory/ene.go
+++ b/src/devices/memory/ene.go
@@ -1,0 +1,379 @@
+package memory
+
+// ENE SMBus memory RGB support is based on the same register protocol used by
+// OpenRGB's ENESMBusController for DRAM controllers.
+
+import (
+	"OpenLinkHub/src/config"
+	"OpenLinkHub/src/dashboard"
+	"OpenLinkHub/src/logger"
+	"OpenLinkHub/src/smbus"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	memoryProtocolCorsair = "corsair"
+	memoryProtocolENE     = "ene"
+
+	eneCommandSelectRegister = 0x00
+	eneCommandWriteValue     = 0x01
+	eneCommandWriteBlock     = 0x03
+	eneCommandReadValue      = 0x81
+
+	eneApplyValue = 0x01
+	eneMaxBlock   = 3
+
+	eneRegDeviceName      = 0x1000
+	eneRegMicronCheck     = 0x1030
+	eneRegConfigTable     = 0x1c00
+	eneRegColorsDirect    = 0x8000
+	eneRegColorsEffect    = 0x8010
+	eneRegDirect          = 0x8020
+	eneRegApply           = 0x80a0
+	eneRegSlotIndex       = 0x80f8
+	eneRegI2CAddress      = 0x80f9
+	eneRegColorsDirectV2  = 0x8100
+	eneRegColorsEffectV2  = 0x8160
+	eneConfigLedCount     = 0x02
+	eneDefaultLedChannels = 8
+	eneMaxLedChannels     = 32
+)
+
+var eneRamAddresses = []byte{
+	0x70,
+	0x71,
+	0x72,
+	0x73,
+	0x74,
+	0x75,
+	0x76,
+	0x77,
+	0x4f,
+	0x66,
+	0x67,
+	0x39,
+	0x3a,
+	0x3b,
+	0x3c,
+	0x3d,
+}
+
+func (d *Device) getENEDevices(modules []RAMModule) map[int]*Devices {
+	devices := make(map[int]*Devices)
+
+	d.remapENEDevices()
+
+	channelId := 0
+	for _, address := range eneRamAddresses {
+		if !d.testENEController(address) {
+			continue
+		}
+
+		version := d.readENEString(address, eneRegDeviceName, 16)
+		configTable := d.readENEConfigTable(address)
+		ledChannels := eneLedCount(configTable)
+		directRegister, effectRegister := eneRegistersForVersion(version, eneConfiguredLedCount(configTable))
+
+		sku := ""
+		var module *RAMModule
+		if channelId < len(modules) {
+			module = &modules[channelId]
+			sku = strings.TrimSpace(module.SKU)
+		}
+		if sku == "" {
+			sku = strings.TrimSpace(config.GetConfig().MemorySku)
+		}
+
+		device := &Devices{
+			ChannelId:      channelId,
+			DeviceId:       channelId,
+			Sku:            sku,
+			MemoryType:     d.RuntimeMemoryType,
+			LedChannels:    uint8(ledChannels),
+			Protocol:       memoryProtocolENE,
+			Address:        address,
+			Name:           eneDeviceName(sku, version),
+			Label:          d.memoryLabel(channelId),
+			RGB:            d.memoryRGBProfile(channelId),
+			DirectRegister: directRegister,
+			EffectRegister: effectRegister,
+		}
+		d.setENETemperature(device, module)
+
+		if d.Debug {
+			logger.Log(logger.Fields{"memoryDevice": device, "version": version, "configTable": fmt.Sprintf("% 2x", configTable)}).Info("ENE Memory DIMM Info - Device")
+		}
+		if d.SkuLine == "" {
+			d.SkuLine = device.Name
+		}
+		devices[channelId] = device
+		d.LEDChannels += ledChannels
+		channelId++
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	return devices
+}
+
+func (d *Device) remapENEDevices() {
+	if !d.eneAddressResponds(0x77) {
+		return
+	}
+
+	addressListIndex := -1
+	for slot := 0; slot < maximumRegisters; slot++ {
+		if !d.eneAddressResponds(0x77) {
+			return
+		}
+
+		for {
+			addressListIndex++
+			if addressListIndex >= len(eneRamAddresses) {
+				return
+			}
+			if !d.eneAddressResponds(eneRamAddresses[addressListIndex]) {
+				break
+			}
+		}
+
+		address := eneRamAddresses[addressListIndex]
+		if d.Debug {
+			logger.Log(logger.Fields{"slot": slot, "address": address}).Info("Remapping ENE memory slot")
+		}
+		if err := d.eneWriteRegister(0x77, eneRegSlotIndex, byte(slot)); err != nil {
+			logger.Log(logger.Fields{"slot": slot, "address": address, "error": err}).Warn("Unable to select ENE memory slot for remap")
+			return
+		}
+		if err := d.eneWriteRegister(0x77, eneRegI2CAddress, address<<1); err != nil {
+			logger.Log(logger.Fields{"slot": slot, "address": address, "error": err}).Warn("Unable to remap ENE memory slot")
+			return
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+}
+
+func (d *Device) eneAddressResponds(address byte) bool {
+	if _, err := smbus.ReadByte(d.dev.File, address); err == nil {
+		return true
+	}
+	if _, err := smbus.ReadRegister(d.dev.File, address, 0x00); err == nil {
+		return true
+	}
+	return false
+}
+
+func (d *Device) testENEController(address byte) bool {
+	if !d.eneAddressResponds(address) {
+		return false
+	}
+
+	for register := byte(0xa0); register < 0xb0; register++ {
+		value, err := smbus.ReadRegister(d.dev.File, address, register)
+		if err != nil {
+			return false
+		}
+		if value != register-0xa0 {
+			return false
+		}
+	}
+
+	value := d.readENERawString(address, eneRegMicronCheck, 16)
+	if strings.TrimRight(string(value), "\x00") == "Micron" {
+		return false
+	}
+	return true
+}
+
+func (d *Device) readENEConfigTable(address byte) []byte {
+	configTable := make([]byte, 64)
+	for i := range configTable {
+		value, err := d.eneReadRegister(address, eneRegConfigTable+uint16(i))
+		if err != nil {
+			return configTable
+		}
+		configTable[i] = value
+	}
+	return configTable
+}
+
+func eneLedCount(configTable []byte) int {
+	ledChannels := eneConfiguredLedCount(configTable)
+	if ledChannels <= 0 {
+		ledChannels = eneDefaultLedChannels
+	}
+	if ledChannels > eneMaxLedChannels {
+		ledChannels = eneMaxLedChannels
+	}
+	return ledChannels
+}
+
+func eneConfiguredLedCount(configTable []byte) int {
+	if len(configTable) > eneConfigLedCount {
+		return int(configTable[eneConfigLedCount])
+	}
+	return 0
+}
+
+func eneRegistersForVersion(version string, configuredLedChannels int) (uint16, uint16) {
+	if strings.HasPrefix(version, "AUDA0-E6K5") || configuredLedChannels > 5 {
+		return eneRegColorsDirectV2, eneRegColorsEffectV2
+	}
+	return eneRegColorsDirect, eneRegColorsEffect
+}
+
+func eneDeviceName(sku, version string) string {
+	if strings.HasPrefix(strings.ToUpper(sku), "F5") {
+		return "G.SKILL Trident Z5 RGB"
+	}
+	if strings.HasPrefix(strings.ToUpper(sku), "F4") {
+		return "G.SKILL Trident Z RGB"
+	}
+	if version != "" {
+		return "ENE DRAM RGB"
+	}
+	return "G.SKILL / ENE DRAM RGB"
+}
+
+func (d *Device) memoryLabel(channelId int) string {
+	label := "Set Label"
+	if d.DeviceProfile == nil {
+		logger.Log(logger.Fields{"serial": d.Serial}).Warn("DeviceProfile is not set, probably first startup")
+		return label
+	}
+	if lb, ok := d.DeviceProfile.Labels[channelId]; ok && len(lb) > 0 {
+		label = lb
+	}
+	return label
+}
+
+func (d *Device) memoryRGBProfile(channelId int) string {
+	rgbProfile := "static"
+	if d.DeviceProfile == nil {
+		logger.Log(logger.Fields{"serial": d.Serial}).Warn("DeviceProfile is not set, probably first startup")
+		return rgbProfile
+	}
+	if rp, ok := d.DeviceProfile.RGBProfiles[channelId]; ok {
+		if d.GetRgbProfile(rp) != nil {
+			return rp
+		}
+		logger.Log(logger.Fields{"serial": d.Serial, "profile": rp}).Warn("Tried to apply non-existing rgb profile")
+	}
+	return rgbProfile
+}
+
+func (d *Device) setENETemperature(device *Devices, module *RAMModule) {
+	if !config.GetConfig().RamTempViaHwmon || module == nil || module.EEPROMPath == "" {
+		return
+	}
+
+	hwmonPath := filepath.Join(filepath.Dir(filepath.Dir(module.EEPROMPath)), "temp1_input")
+	hwmonTemp, err := d.getTemperature(hwmonPath)
+	if err != nil {
+		return
+	}
+
+	device.HwmonPath = hwmonPath
+	device.Temperature = hwmonTemp
+	device.TemperatureString = dashboard.GetDashboard().TemperatureToString(hwmonTemp)
+	device.HasTemps = true
+}
+
+func (d *Device) readENEString(address byte, register uint16, size int) string {
+	return strings.TrimRight(string(d.readENERawString(address, register, size)), "\x00")
+}
+
+func (d *Device) readENERawString(address byte, register uint16, size int) []byte {
+	buffer := make([]byte, 0, size)
+	for i := 0; i < size; i++ {
+		value, err := d.eneReadRegister(address, register+uint16(i))
+		if err != nil {
+			return buffer
+		}
+		buffer = append(buffer, value)
+	}
+	return buffer
+}
+
+func (d *Device) eneReadRegister(address byte, register uint16) (byte, error) {
+	if err := smbus.WriteWord(d.dev.File, address, eneCommandSelectRegister, eneSwapRegister(register)); err != nil {
+		return 0, err
+	}
+	return smbus.ReadRegister(d.dev.File, address, eneCommandReadValue)
+}
+
+func (d *Device) eneWriteRegister(address byte, register uint16, value byte) error {
+	if err := smbus.WriteWord(d.dev.File, address, eneCommandSelectRegister, eneSwapRegister(register)); err != nil {
+		return err
+	}
+	return smbus.WriteRegister(d.dev.File, address, eneCommandWriteValue, value)
+}
+
+func (d *Device) eneWriteBlock(address byte, register uint16, data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+
+	for offset := 0; offset < len(data); offset += eneMaxBlock {
+		end := offset + eneMaxBlock
+		if end > len(data) {
+			end = len(data)
+		}
+		chunk := data[offset:end]
+		if err := smbus.WriteWord(d.dev.File, address, eneCommandSelectRegister, eneSwapRegister(register+uint16(offset))); err != nil {
+			return err
+		}
+		if err := smbus.WriteBlockDataUncached(d.dev.File, address, eneCommandWriteBlock, chunk); err != nil {
+			for _, value := range chunk {
+				if writeErr := smbus.WriteRegister(d.dev.File, address, eneCommandWriteValue, value); writeErr != nil {
+					return writeErr
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (d *Device) transferENE(buffer []byte, device *Devices) uint16 {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	if device == nil || device.Address == 0 {
+		return 0
+	}
+
+	if err := d.eneWriteRegister(device.Address, eneRegDirect, 1); err != nil {
+		logger.Log(logger.Fields{"error": err, "address": device.Address}).Error("Unable to set ENE direct mode")
+		return 0
+	}
+
+	colorBuffer := make([]byte, int(device.LedChannels)*3)
+	for led := 0; led < int(device.LedChannels); led++ {
+		src := led * 3
+		dst := led * 3
+		if src+2 >= len(buffer) {
+			break
+		}
+		colorBuffer[dst] = buffer[src]
+		colorBuffer[dst+1] = buffer[src+2]
+		colorBuffer[dst+2] = buffer[src+1]
+	}
+
+	if d.Debug {
+		logger.Log(logger.Fields{"colorPacket": fmt.Sprintf("% 2x", colorBuffer), "address": device.Address}).Info("ENE Memory Color")
+	}
+	if err := d.eneWriteBlock(device.Address, device.DirectRegister, colorBuffer); err != nil {
+		logger.Log(logger.Fields{"error": err, "address": device.Address}).Error("Unable to write ENE memory color")
+		return 0
+	}
+	if err := d.eneWriteRegister(device.Address, eneRegApply, eneApplyValue); err != nil {
+		logger.Log(logger.Fields{"error": err, "address": device.Address}).Error("Unable to apply ENE memory color")
+	}
+	return 0
+}
+
+func eneSwapRegister(register uint16) uint16 {
+	return ((register << 8) & 0xff00) | ((register >> 8) & 0x00ff)
+}

--- a/src/devices/memory/memory.go
+++ b/src/devices/memory/memory.go
@@ -54,12 +54,16 @@ type Devices struct {
 	Latency            int     `json:"latency"`
 	LedChannels        uint8   `json:"ledChannels"`
 	ColorRegister      uint8   `json:"colorRegister"`
+	Protocol           string  `json:"protocol,omitempty"`
+	Address            byte    `json:"address,omitempty"`
 	Name               string  `json:"name"`
 	Temperature        float32 `json:"temperature"`
 	TemperatureString  string  `json:"temperatureString"`
 	Label              string  `json:"label"`
 	RGB                string  `json:"rgb"`
 	HwmonPath          string  `json:"hwmonPath"`
+	DirectRegister     uint16  `json:"-"`
+	EffectRegister     uint16  `json:"-"`
 	HasTemps           bool    `json:"-"`
 	HasSpeed           bool
 	ContainsPump       bool
@@ -327,7 +331,7 @@ func (d *Device) Stop() {
 				static[i] = []byte{0, 0, 0}
 			}
 			buffer := rgb.SetColor(static)
-			d.transfer(buffer, colorAddresses[k], d.Devices[k].LedChannels, d.Devices[k].ColorRegister)
+			d.writeDeviceColor(d.Devices[k], buffer)
 		}
 	}
 
@@ -726,6 +730,8 @@ func (d *Device) getDevices() int {
 						MemoryType:        d.RuntimeMemoryType,
 						LedChannels:       uint8(metadata.LedChannels),
 						ColorRegister:     metadata.Register,
+						Protocol:          memoryProtocolCorsair,
+						Address:           colorAddresses[i],
 						Name:              metadata.Name,
 						Temperature:       float32(temperature),
 						TemperatureString: temperatureString,
@@ -783,6 +789,10 @@ func (d *Device) getDevices() int {
 				}
 			}
 		}
+	}
+
+	if len(devices) == 0 {
+		devices = d.getENEDevices(modules)
 	}
 
 	d.Devices = devices
@@ -1206,7 +1216,7 @@ func (d *Device) setDeviceColor() {
 			static[i] = []byte{byte(0), byte(0), byte(0)}
 		}
 		buffer = rgb.SetColor(static)
-		d.transfer(buffer, colorAddresses[k], d.Devices[k].LedChannels, d.Devices[k].ColorRegister)
+		d.writeDeviceColor(d.Devices[k], buffer)
 		time.Sleep(5 * time.Millisecond)
 	}
 
@@ -1264,7 +1274,7 @@ func (d *Device) setDeviceColor() {
 				}
 			}
 			buffer = rgb.SetColor(static)
-			d.transfer(buffer, colorAddresses[k], d.Devices[k].LedChannels, d.Devices[k].ColorRegister)
+			d.writeDeviceColor(d.Devices[k], buffer)
 			time.Sleep(10 * time.Millisecond)
 		}
 		return
@@ -1498,12 +1508,34 @@ func (d *Device) setDeviceColor() {
 	}(lightChannels)
 }
 
+// writeDeviceColor writes RGB data using the memory module's RGB protocol.
+func (d *Device) writeDeviceColor(device *Devices, data []byte) {
+	if device == nil || device.LedChannels == 0 {
+		return
+	}
+
+	if device.Protocol == memoryProtocolENE {
+		d.transferENE(data, device)
+		return
+	}
+
+	address := device.Address
+	if address == 0 && device.ChannelId >= 0 && device.ChannelId < len(colorAddresses) {
+		address = colorAddresses[device.ChannelId]
+	}
+	if address == 0 {
+		logger.Log(logger.Fields{"channelId": device.ChannelId, "name": device.Name}).Error("Unable to write memory color without SMBus address")
+		return
+	}
+	d.transfer(data, address, device.LedChannels, device.ColorRegister)
+}
+
 // writeColor will write color data to the device
 func (d *Device) writeColor(data []byte, deviceId int) {
 	if d.DeviceProfile.OpenRGBIntegration {
 		return
 	}
-	d.transfer(data, colorAddresses[deviceId], d.Devices[deviceId].LedChannels, d.Devices[deviceId].ColorRegister)
+	d.writeDeviceColor(d.Devices[deviceId], data)
 }
 
 // writeColorEx will write data to the device from OpenRGB client
@@ -1591,7 +1623,7 @@ func (d *Device) startQueueWorker() {
 
 			for _, channelId := range keys {
 				data := packetMap[channelId]
-				d.transfer(data, colorAddresses[channelId], d.Devices[channelId].LedChannels, d.Devices[channelId].ColorRegister)
+				d.writeDeviceColor(d.Devices[channelId], data)
 				_ = channelId
 			}
 			d.deviceLock.Unlock()

--- a/src/smbus/smbus.go
+++ b/src/smbus/smbus.go
@@ -21,6 +21,7 @@ const (
 	i2cSmbus            = 0x0720
 	i2cRead      uint8  = 1
 	i2cWrite     uint8  = 0
+	i2cByte      uint32 = 1
 	i2cByteData  uint32 = 2
 	i2cWordData  uint32 = 3
 	i2cBlockData uint32 = 5
@@ -110,13 +111,24 @@ func Open(device string) (*Connection, error) {
 
 // WriteBlockData will write a byte array to register
 func WriteBlockData(f *os.File, address, register uint8, buf []byte) error {
+	return writeBlockData(f, address, register, buf, true)
+}
+
+// WriteBlockDataUncached will write a byte array to register without packet caching.
+func WriteBlockDataUncached(f *os.File, address, register uint8, buf []byte) error {
+	return writeBlockData(f, address, register, buf, false)
+}
+
+func writeBlockData(f *os.File, address, register uint8, buf []byte, useCache bool) error {
 	if len(buf) > int(i2csmBusMax) {
 		return errors.New("buffer is too long for this type")
 	}
 
 	k := cacheKey{addr: address, reg: register}
-	if prev, ok := cacheData[k]; ok && bytes.Equal(prev, buf) {
-		return nil
+	if useCache {
+		if prev, ok := cacheData[k]; ok && bytes.Equal(prev, buf) {
+			return nil
+		}
 	}
 
 	if err := ioctl(f.Fd(), i2cSlave, uintptr(address)); err != nil {
@@ -135,12 +147,62 @@ func WriteBlockData(f *os.File, address, register uint8, buf []byte) error {
 	}
 	ptr := unsafe.Pointer(&cmd)
 	err := ioctl(f.Fd(), i2cSmbus, uintptr(ptr))
-	if err == nil {
+	if useCache && err == nil {
 		cp := make([]byte, len(buf))
 		copy(cp, buf)
 		cacheData[k] = cp
 	}
 	return err
+}
+
+// WriteRegister will write a byte to a register
+func WriteRegister(f *os.File, address, register, value uint8) error {
+	if err := ioctl(f.Fd(), i2cSlave, uintptr(address)); err != nil {
+		return err
+	}
+
+	cmd := i2cCommand{
+		mode:    i2cWrite,
+		command: register,
+		length:  i2cByteData,
+		pointer: unsafe.Pointer(&value),
+	}
+	ptr := unsafe.Pointer(&cmd)
+	return ioctl(f.Fd(), i2cSmbus, uintptr(ptr))
+}
+
+// WriteWord writes a 2-byte word to a designated register.
+func WriteWord(f *os.File, addr, reg uint8, value uint16) error {
+	if err := ioctl(f.Fd(), i2cSlave, uintptr(addr)); err != nil {
+		return err
+	}
+
+	cmd := i2cCommand{
+		mode:    i2cWrite,
+		command: reg,
+		length:  i2cWordData,
+		pointer: unsafe.Pointer(&value),
+	}
+	ptr := unsafe.Pointer(&cmd)
+	return ioctl(f.Fd(), i2cSmbus, uintptr(ptr))
+}
+
+// ReadByte will read a byte without specifying a register.
+func ReadByte(f *os.File, address uint8) (uint8, error) {
+	if err := ioctl(f.Fd(), i2cSlave, uintptr(address)); err != nil {
+		return 0, err
+	}
+
+	var v uint8
+	var cmd = i2cCommand{
+		mode:    i2cRead,
+		command: 0,
+		length:  i2cByte,
+		pointer: unsafe.Pointer(&v),
+	}
+	ptr := unsafe.Pointer(&cmd)
+	err := ioctl(f.Fd(), i2cSmbus, uintptr(ptr))
+	return v, err
 }
 
 // ReadRegister will read byte from a register


### PR DESCRIPTION
Detect ENE-backed DRAM RGB devices such as G.SKILL Trident Z5, route
memory color writes through protocol-specific handlers, and add the
SMBus operations needed for ENE register access.

Also fix a Go vet warning in audio error formatting so the full test
suite can pass.
