### PR TITLE
Update the systemd unit to reload udev rules and retrigger Corsair usb devices before starting OpenLinkHub.

### DIFF
--- a/OpenLinkHub.service
+++ b/OpenLinkHub.service
@@ -1,12 +1,15 @@
 [Unit]
 Description=Open source interface for iCUE LINK System Hub, Corsair AIOs and Hubs
-After=sleep.target
+After=sleep.target systemd-sysusers.service systemd-udevd.service
 StartLimitIntervalSec=60
 StartLimitBurst=5
 
 [Service]
 User=openlinkhub
 WorkingDirectory=/opt/OpenLinkHub
+ExecStartPre=+/usr/bin/udevadm control --reload-rules
+ExecStartPre=+/usr/bin/udevadm trigger --subsystem-match=usb --attr-match=idVendor=1b1c
+ExecStartPre=+/usr/bin/udevadm settle --timeout=30
 ExecStart=/opt/OpenLinkHub/OpenLinkHub
 ExecReload=/bin/kill -s HUP $MAINPID
 RestartSec=5


### PR DESCRIPTION
At boot, `systemd-udevd` can parse `99-openlinkhub.rules` before the `openlinkhub` user is resolvable, producing an error for every rule :
```text
Failed to resolve user 'openlinkhub', ignoring: Unknown user
```
When this happens, the owner assignment is ignored until devices are replugged or udev is retriggered.
The unit now starts after `systemd-sysusers.service` and `systemd-udevd.service`, then runs:
```ini
udevadm control --reload-rules
udevadm trigger --subsystem-match=usb --attr-match=idVendor=1b1c
udevadm settle --timeout=30
```

This reloads the rules once the `openlinkhub` user should be available, retriggers only usb devices from Corsair, and waits for udev to settle before starting the daemon.