### PR TITLE
Add DE (ISO) layout for K60 RGB PRO Low Profile

### DIFF
--- a/database/keyboard/k60rgbprolp-de.json
+++ b/database/keyboard/k60rgbprolp-de.json
@@ -1,0 +1,2439 @@
+{
+  "version": 1,
+  "uppercaseClass": "key-uppercase",
+  "fontSize": 14,
+  "key": "k60rgbprolp-default",
+  "device": "K60 RGB PRO LP",
+  "layout": "DE",
+  "rows": 6,
+  "modifierPosition": 15,
+  "row": {
+    "0": {
+      "keys": {
+        "1": {
+          "keyName": "ESC",
+          "width": 65,
+          "height": 70,
+          "left": 0,
+          "top": 0,
+          "zone": 1,
+          "packetIndex": [
+            37
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 0
+          },
+          "keyData": [
+            41
+          ],
+          "keyHash": [
+            "2199023255552"
+          ],
+          "default": true
+        },
+        "2": {
+          "keyName": "F1",
+          "width": 65,
+          "height": 70,
+          "left": 95,
+          "top": 0,
+          "packetIndex": [
+            54
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyEmpty": [
+            "keyboard-key-empty"
+          ],
+          "keyData": [
+            58
+          ],
+          "keyHash": [
+            "288230376151711744"
+          ],
+          "default": true,
+          "isLock": true
+        },
+        "3": {
+          "keyName": "F2",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [
+            55
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            59
+          ],
+          "keyHash": [
+            "576460752303423488"
+          ],
+          "default": true
+        },
+        "4": {
+          "keyName": "F3",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [
+            56
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            60
+          ],
+          "keyHash": [
+            "1152921504606846976"
+          ],
+          "default": true,
+          "actionType": 12
+        },
+        "5": {
+          "keyName": "F4",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [
+            57
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            61
+          ],
+          "keyHash": [
+            "2305843009213693952"
+          ],
+          "default": true,
+          "actionType": 11
+        },
+        "6": {
+          "keyName": "F5",
+          "width": 65,
+          "height": 70,
+          "left": 55,
+          "top": 0,
+          "packetIndex": [
+            58
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyEmpty": [
+            "keyboard-key-empty"
+          ],
+          "keyData": [
+            62
+          ],
+          "keyHash": [
+            "4611686018427387904"
+          ],
+          "default": true,
+          "mediaKey": true,
+          "fnActionType": 1,
+          "fnActionCommand": 3
+        },
+        "7": {
+          "keyName": "F6",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [
+            59
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            63
+          ],
+          "keyHash": [
+            "9223372036854775808"
+          ],
+          "default": true
+        },
+        "8": {
+          "keyName": "F7",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [
+            60
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            64
+          ],
+          "keyHash": [
+            "18446744073709551616"
+          ],
+          "default": true,
+          "mediaKey": true,
+          "fnActionType": 1,
+          "fnActionCommand": 2
+        },
+        "9": {
+          "keyName": "F8",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [
+            61
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            65
+          ],
+          "keyHash": [
+            "36893488147419103232"
+          ],
+          "default": true,
+          "mediaKey": true,
+          "fnActionType": 1,
+          "fnActionCommand": 1
+        },
+        "10": {
+          "keyName": "F9",
+          "width": 65,
+          "height": 70,
+          "left": 60,
+          "top": 0,
+          "packetIndex": [
+            62
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyEmpty": [
+            "keyboard-key-empty"
+          ],
+          "keyData": [
+            66
+          ],
+          "keyHash": [
+            "73786976294838206464"
+          ],
+          "default": true,
+          "mediaKey": true,
+          "fnActionType": 1,
+          "fnActionCommand": 4
+        },
+        "11": {
+          "keyName": "F10",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [
+            63
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            67
+          ],
+          "keyHash": [
+            "147573952589676412928"
+          ],
+          "default": true,
+          "mediaKey": true,
+          "fnActionType": 1,
+          "fnActionCommand": 5
+        },
+        "12": {
+          "keyName": "F11",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [
+            64
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            68
+          ],
+          "keyHash": [
+            "295147905179352825856"
+          ],
+          "default": true,
+          "mediaKey": true,
+          "fnActionType": 1,
+          "fnActionCommand": 6
+        },
+        "13": {
+          "keyName": "F12",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [
+            65
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            69
+          ],
+          "keyHash": [
+            "590295810358705651712"
+          ],
+          "default": true,
+          "mediaKey": true,
+          "fnActionType": 1,
+          "fnActionCommand": 7
+        },
+        "14": {
+          "keyName": "Dru",
+          "width": 65,
+          "height": 70,
+          "left": 25,
+          "top": 0,
+          "packetIndex": [
+            66
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyEmpty": [
+            "keyboard-key-empty"
+          ],
+          "keyData": [
+            70
+          ],
+          "keyHash": [
+            "1180591620717411303424"
+          ],
+          "default": true
+        },
+        "15": {
+          "keyName": "Rol",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [
+            67
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            71
+          ],
+          "keyHash": [
+            "2361183241434822606848"
+          ],
+          "default": true
+        },
+        "16": {
+          "keyName": "Pau",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 0,
+          "packetIndex": [
+            68
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            72
+          ],
+          "default": true,
+          "keyHash": [
+            "4722366482869645213696"
+          ]
+        }
+      }
+    },
+    "1": {
+      "keys": {
+        "17": {
+          "keyName": "^ °",
+          "width": 65,
+          "height": 70,
+          "left": 0,
+          "top": 15,
+          "packetIndex": [
+            49
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            53
+          ],
+          "default": true,
+          "keyHash": [
+            "9007199254740992"
+          ]
+        },
+        "18": {
+          "keyName": "1",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            26
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            30
+          ],
+          "default": true,
+          "keyHash": [
+            "1073741824"
+          ]
+        },
+        "19": {
+          "keyName": "2",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            27
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            31
+          ],
+          "default": true,
+          "keyHash": [
+            "2147483648"
+          ]
+        },
+        "20": {
+          "keyName": "3",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            28
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            32
+          ],
+          "default": true,
+          "keyHash": [
+            "4294967296"
+          ]
+        },
+        "21": {
+          "keyName": "4",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            29
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            33
+          ],
+          "default": true,
+          "keyHash": [
+            "8589934592"
+          ]
+        },
+        "22": {
+          "keyName": "5",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            30
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            34
+          ],
+          "default": true,
+          "keyHash": [
+            "17179869184"
+          ]
+        },
+        "23": {
+          "keyName": "6",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            31
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            35
+          ],
+          "default": true,
+          "keyHash": [
+            "34359738368"
+          ]
+        },
+        "24": {
+          "keyName": "7",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            32
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            36
+          ],
+          "default": true,
+          "keyHash": [
+            "68719476736"
+          ]
+        },
+        "25": {
+          "keyName": "8",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            33
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            37
+          ],
+          "default": true,
+          "keyHash": [
+            "137438953472"
+          ]
+        },
+        "26": {
+          "keyName": "9",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            34
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            38
+          ],
+          "default": true,
+          "keyHash": [
+            "274877906944"
+          ]
+        },
+        "27": {
+          "keyName": "0",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            35
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            39
+          ],
+          "default": true,
+          "keyHash": [
+            "549755813888"
+          ]
+        },
+        "28": {
+          "keyName": "Sz",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            41
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            45
+          ],
+          "default": true,
+          "keyHash": [
+            "35184372088832"
+          ]
+        },
+        "29": {
+          "keyName": "' `",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            42
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            46
+          ],
+          "default": true,
+          "keyHash": [
+            "70368744177664"
+          ]
+        },
+        "30": {
+          "keyName": "<---",
+          "width": 150,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            38
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            42
+          ],
+          "default": true,
+          "keySpace": "keyboard-key wide3",
+          "keyHash": [
+            "4398046511104"
+          ]
+        },
+        "31": {
+          "keyName": "Einfg",
+          "width": 65,
+          "height": 70,
+          "left": 25,
+          "top": 15,
+          "packetIndex": [
+            69
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            73
+          ],
+          "default": true,
+          "keyEmpty": [
+            "keyboard-key-empty"
+          ],
+          "keyHash": [
+            "9444732965739290427392"
+          ]
+        },
+        "32": {
+          "keyName": "Pos 1",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            70
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            74
+          ],
+          "default": true,
+          "keyHash": [
+            "18889465931478580854784"
+          ]
+        },
+        "33": {
+          "keyName": "Bild↑",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            71
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            75
+          ],
+          "default": true,
+          "keyHash": [
+            "37778931862957161709568"
+          ]
+        },
+        "34": {
+          "keyName": "Num",
+          "width": 65,
+          "height": 70,
+          "left": 25,
+          "top": 15,
+          "packetIndex": [
+            79
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            83
+          ],
+          "default": true,
+          "keyEmpty": [
+            "keyboard-key-empty"
+          ],
+          "keyHash": [
+            "9671406556917033397649408"
+          ]
+        },
+        "35": {
+          "keyName": "/",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            80
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            84
+          ],
+          "default": true,
+          "keyHash": [
+            "19342813113834066795298816"
+          ]
+        },
+        "36": {
+          "keyName": "*",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            81
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            85
+          ],
+          "default": true,
+          "keyHash": [
+            "38685626227668133590597632"
+          ]
+        },
+        "37": {
+          "keyName": "-",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            82
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            86
+          ],
+          "default": true,
+          "keyHash": [
+            "77371252455336267181195264"
+          ]
+        }
+      }
+    },
+    "2": {
+      "top": 65,
+      "keys": {
+        "38": {
+          "keyName": "Tab",
+          "width": 108,
+          "height": 70,
+          "left": 0,
+          "top": 15,
+          "packetIndex": [
+            39
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            43
+          ],
+          "default": true,
+          "keySpace": "keyboard-key wide",
+          "keyHash": [
+            "8796093022208"
+          ]
+        },
+        "39": {
+          "keyName": "Q",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            16
+          ],
+          "color": {
+            "red": 255,
+            "green": 0,
+            "blue": 0
+          },
+          "keyData": [
+            20
+          ],
+          "default": true,
+          "keyHash": [
+            "1048576"
+          ]
+        },
+        "40": {
+          "keyName": "W",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            22
+          ],
+          "color": {
+            "red": 255,
+            "green": 0,
+            "blue": 0
+          },
+          "keyData": [
+            26
+          ],
+          "default": true,
+          "keyHash": [
+            "67108864"
+          ]
+        },
+        "41": {
+          "keyName": "E",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            4
+          ],
+          "color": {
+            "red": 255,
+            "green": 0,
+            "blue": 0
+          },
+          "keyData": [
+            8
+          ],
+          "default": true,
+          "keyHash": [
+            "256"
+          ]
+        },
+        "42": {
+          "keyName": "R",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            17
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            21
+          ],
+          "default": true,
+          "keyHash": [
+            "2097152"
+          ]
+        },
+        "43": {
+          "keyName": "T",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            19
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            23
+          ],
+          "default": true,
+          "keyHash": [
+            "8388608"
+          ]
+        },
+        "44": {
+          "keyName": "Z",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            24
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            28
+          ],
+          "default": true,
+          "keyHash": [
+            "268435456"
+          ]
+        },
+        "45": {
+          "keyName": "U",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            20
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            24
+          ],
+          "default": true,
+          "keyHash": [
+            "16777216"
+          ]
+        },
+        "46": {
+          "keyName": "I",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            8
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            12
+          ],
+          "default": true,
+          "keyHash": [
+            "4096"
+          ]
+        },
+        "47": {
+          "keyName": "O",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            14
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            18
+          ],
+          "default": true,
+          "keyHash": [
+            "262144"
+          ]
+        },
+        "48": {
+          "keyName": "P",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            15
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            19
+          ],
+          "default": true,
+          "keyHash": [
+            "524288"
+          ]
+        },
+        "49": {
+          "keyName": "Ü",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            43
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            47
+          ],
+          "default": true,
+          "keyHash": [
+            "140737488355328"
+          ]
+        },
+        "50": {
+          "keyName": "+",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            44
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            48
+          ],
+          "default": true,
+          "keyHash": [
+            "281474976710656"
+          ]
+        },
+        "51": {
+          "keyName": "Entf",
+          "width": 65,
+          "height": 70,
+          "left": 147,
+          "top": 15,
+          "packetIndex": [
+            72
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            76
+          ],
+          "default": true,
+          "keyEmpty": [
+            "keyboard-key-empty",
+            "keyboard-key-empty",
+            "keyboard-key-empty"
+          ],
+          "keyHash": [
+            "75557863725914323419136"
+          ]
+        },
+        "52": {
+          "keyName": "Ende",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            73
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            77
+          ],
+          "default": true,
+          "keyHash": [
+            "151115727451828646838272"
+          ]
+        },
+        "53": {
+          "keyName": "Bild↓",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            74
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            78
+          ],
+          "default": true,
+          "keyHash": [
+            "302231454903657293676544"
+          ]
+        },
+        "54": {
+          "keyName": "7",
+          "width": 65,
+          "height": 70,
+          "left": 25,
+          "top": 15,
+          "packetIndex": [
+            91
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            95
+          ],
+          "default": true,
+          "keyEmpty": [
+            "keyboard-key-empty"
+          ],
+          "keyHash": [
+            "39614081257132168796771975168"
+          ]
+        },
+        "55": {
+          "keyName": "8",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            92
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            96
+          ],
+          "default": true,
+          "keyHash": [
+            "79228162514264337593543950336"
+          ]
+        },
+        "56": {
+          "keyName": "9",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            93
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            97
+          ],
+          "default": true,
+          "keyHash": [
+            "158456325028528675187087900672"
+          ]
+        },
+        "57": {
+          "keyName": "+",
+          "width": 65,
+          "height": 155,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            83
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            87
+          ],
+          "default": true,
+          "keySpace": "keyboard-key-125",
+          "keyHash": [
+            "154742504910672534362390528"
+          ]
+        }
+      }
+    },
+    "3": {
+      "keys": {
+        "58": {
+          "keyName": "CAPS",
+          "width": 131,
+          "height": 70,
+          "left": 0,
+          "top": 15,
+          "packetIndex": [
+            53
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            57
+          ],
+          "default": true,
+          "keySpace": "keyboard-key wide",
+          "keyHash": [
+            "144115188075855872"
+          ]
+        },
+        "59": {
+          "keyName": "A",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            0
+          ],
+          "color": {
+            "red": 255,
+            "green": 0,
+            "blue": 0
+          },
+          "keyData": [
+            4
+          ],
+          "default": true,
+          "keyHash": [
+            "16"
+          ]
+        },
+        "60": {
+          "keyName": "S",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            18
+          ],
+          "color": {
+            "red": 255,
+            "green": 0,
+            "blue": 0
+          },
+          "keyData": [
+            22
+          ],
+          "default": true,
+          "keyHash": [
+            "4194304"
+          ]
+        },
+        "61": {
+          "keyName": "D",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            3
+          ],
+          "color": {
+            "red": 255,
+            "green": 0,
+            "blue": 0
+          },
+          "keyData": [
+            7
+          ],
+          "default": true,
+          "keyHash": [
+            "128"
+          ]
+        },
+        "62": {
+          "keyName": "F",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            5
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            9
+          ],
+          "default": true,
+          "keyHash": [
+            "512"
+          ]
+        },
+        "63": {
+          "keyName": "G",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            30
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            10
+          ],
+          "default": true,
+          "keyHash": [
+            "1024"
+          ]
+        },
+        "64": {
+          "keyName": "H",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            7
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            11
+          ],
+          "default": true,
+          "keyHash": [
+            "2048"
+          ]
+        },
+        "65": {
+          "keyName": "J",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            9
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            13
+          ],
+          "default": true,
+          "keyHash": [
+            "8192"
+          ]
+        },
+        "66": {
+          "keyName": "K",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "zone": 2,
+          "packetIndex": [
+            10
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            14
+          ],
+          "default": true,
+          "keyHash": [
+            "16384"
+          ]
+        },
+        "67": {
+          "keyName": "L",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            11
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            15
+          ],
+          "default": true,
+          "keyHash": [
+            "32768"
+          ]
+        },
+        "68": {
+          "keyName": "Ö",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            47
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            51
+          ],
+          "default": true,
+          "keyHash": [
+            "2251799813685248"
+          ]
+        },
+        "69": {
+          "keyName": "Ä",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            48
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            52
+          ],
+          "default": true,
+          "keyHash": [
+            "4503599627370496"
+          ]
+        },
+        "70": {
+          "keyName": "# '",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            46
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            50
+          ],
+          "default": true,
+          "keyHash": [
+            "1125899906842624"
+          ]
+        },
+        "71": {
+          "keyName": "Enter",
+          "width": 84,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            36
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            40
+          ],
+          "default": true,
+          "keySpace": "keyboard-key wide",
+          "keyHash": [
+            "1099511627776"
+          ]
+        },
+        "72": {
+          "keyName": "4",
+          "width": 65,
+          "height": 70,
+          "left": 275,
+          "top": 15,
+          "packetIndex": [
+            88
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyEmpty": [
+            "keyboard-key-empty",
+            "keyboard-key-empty",
+            "keyboard-key-empty",
+            "keyboard-key-empty",
+            "keyboard-key-empty"
+          ],
+          "keyData": [
+            92
+          ],
+          "default": true,
+          "keyHash": [
+            "4951760157141521099596496896"
+          ]
+        },
+        "73": {
+          "keyName": "5",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            89
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            93
+          ],
+          "default": true,
+          "keyHash": [
+            "9903520314283042199192993792"
+          ]
+        },
+        "74": {
+          "keyName": "6",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            90
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            94
+          ],
+          "default": true,
+          "keyHash": [
+            "19807040628566084398385987584"
+          ]
+        }
+      }
+    },
+    "4": {
+      "top": 65,
+      "keys": {
+        "75": {
+          "keyName": "Shift",
+          "width": 90,
+          "height": 70,
+          "left": 0,
+          "top": 15,
+          "packetIndex": [
+            102
+          ],
+          "color": {
+            "red": 255,
+            "green": 255,
+            "blue": 0
+          },
+          "keyData": [
+            106
+          ],
+          "default": true,
+          "keySpace": "keyboard-key wide",
+          "keyHash": [
+            "81129638414606681695789005144064"
+          ],
+          "modifierPacketValue": 4
+        },
+        "76": {
+          "keyName": "< >",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            96
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            100
+          ],
+          "default": true,
+          "keyHash": [
+            "1267650600228229401496703205376"
+          ]
+        },
+        "77": {
+          "keyName": "Y",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            25
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            29
+          ],
+          "default": true,
+          "keyHash": [
+            "536870912"
+          ]
+        },
+        "78": {
+          "keyName": "X",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            23
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            27
+          ],
+          "default": true,
+          "keyHash": [
+            "134217728"
+          ]
+        },
+        "79": {
+          "keyName": "C",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            2
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            6
+          ],
+          "default": true,
+          "keyHash": [
+            "64"
+          ]
+        },
+        "80": {
+          "keyName": "V",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            21
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            25
+          ],
+          "default": true,
+          "keyHash": [
+            "33554432"
+          ]
+        },
+        "81": {
+          "keyName": "B",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            1
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            5
+          ],
+          "default": true,
+          "keyHash": [
+            "32"
+          ]
+        },
+        "82": {
+          "keyName": "N",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "zone": 2,
+          "packetIndex": [
+            13
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            17
+          ],
+          "default": true,
+          "keyHash": [
+            "131072"
+          ]
+        },
+        "83": {
+          "keyName": "M",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            12
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            16
+          ],
+          "default": true,
+          "keyHash": [
+            "65536"
+          ]
+        },
+        "84": {
+          "keyName": ", ;",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            50
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            54
+          ],
+          "default": true,
+          "keyHash": [
+            "18014398509481984"
+          ]
+        },
+        "85": {
+          "keyName": ". :",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            51
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            55
+          ],
+          "default": true,
+          "keyHash": [
+            "36028797018963968"
+          ]
+        },
+        "86": {
+          "keyName": "- _",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            52
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            56
+          ],
+          "default": true,
+          "keyHash": [
+            "72057594037927936"
+          ]
+        },
+        "87": {
+          "keyName": "Shift",
+          "width": 205,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            106
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            110
+          ],
+          "default": true,
+          "keySpace": "keyboard-key wide3",
+          "keyHash": [
+            "1298074214633706907132624082305024"
+          ],
+          "modifierPacketValue": 64
+        },
+        "88": {
+          "keyName": "↑",
+          "width": 65,
+          "height": 70,
+          "left": 105,
+          "top": 15,
+          "packetIndex": [
+            78
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            82
+          ],
+          "default": true,
+          "keyEmpty": [
+            "keyboard-key-empty",
+            "keyboard-key-empty"
+          ],
+          "keyHash": [
+            "4835703278458516698824704"
+          ]
+        },
+        "89": {
+          "keyName": "1",
+          "width": 65,
+          "height": 70,
+          "left": 105,
+          "top": 15,
+          "packetIndex": [
+            85
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            89
+          ],
+          "default": true,
+          "keyEmpty": [
+            "keyboard-key-empty",
+            "keyboard-key-empty"
+          ],
+          "keyHash": [
+            "618970019642690137449562112"
+          ]
+        },
+        "90": {
+          "keyName": "2",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            86
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            90
+          ],
+          "default": true,
+          "keyHash": [
+            "1237940039285380274899124224"
+          ]
+        },
+        "91": {
+          "keyName": "3",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            87
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            91
+          ],
+          "default": true,
+          "keyHash": [
+            "2475880078570760549798248448"
+          ]
+        },
+        "92": {
+          "keyName": "Enter",
+          "width": 65,
+          "height": 155,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            84
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            88
+          ],
+          "default": true,
+          "keySpace": "keyboard-key-125",
+          "keyHash": [
+            "309485009821345068724781056"
+          ]
+        }
+      }
+    },
+    "5": {
+      "keys": {
+        "93": {
+          "keyName": "Strg",
+          "width": 90,
+          "height": 70,
+          "left": 0,
+          "top": 15,
+          "packetIndex": [
+            101
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            105
+          ],
+          "default": true,
+          "keyHash": [
+            "40564819207303340847894502572032"
+          ],
+          "modifierPacketValue": 2
+        },
+        "94": {
+          "keyName": "Win",
+          "width": 90,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            104
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            108
+          ],
+          "default": true,
+          "keyHash": [
+            "324518553658426726783156020576256"
+          ]
+        },
+        "95": {
+          "keyName": "Alt",
+          "width": 90,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            103
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            107
+          ],
+          "default": true,
+          "keyHash": [
+            "162259276829213363391578010288128"
+          ],
+          "modifierPacketValue": 8
+        },
+        "96": {
+          "keyName": "----------",
+          "width": 151,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            40
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            44
+          ],
+          "default": true,
+          "keySpace": "keyboard-key wide8",
+          "keyHash": [
+            "17592186044416"
+          ]
+        },
+        "97": {
+          "keyName": "Alt",
+          "width": 90,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            107
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            111
+          ],
+          "default": true,
+          "keyHash": [
+            "2596148429267413814265248164610048"
+          ],
+          "modifierPacketValue": 128
+        },
+        "98": {
+          "keyName": "Fn",
+          "width": 90,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            118
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            122
+          ],
+          "default": true,
+          "keyHash": [
+            "5316911983139663491615228241121378304"
+          ]
+        },
+        "99": {
+          "keyName": "Menu",
+          "width": 90,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            97
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            101
+          ],
+          "default": true,
+          "keyHash": [
+            "2535301200456458802993406410752"
+          ]
+        },
+        "100": {
+          "keyName": "Strg",
+          "width": 90,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            105
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            109
+          ],
+          "default": true,
+          "keySpace": "keyboard-key wide",
+          "keyHash": [
+            "649037107316853453566312041152512"
+          ],
+          "modifierPacketValue": 32
+        },
+        "101": {
+          "keyName": "←",
+          "width": 65,
+          "height": 70,
+          "left": 25,
+          "top": 15,
+          "packetIndex": [
+            76
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            80
+          ],
+          "default": true,
+          "keyEmpty": [
+            "keyboard-key-empty"
+          ],
+          "keyHash": [
+            "1208925819614629174706176"
+          ]
+        },
+        "102": {
+          "keyName": "↓",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            77
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            81
+          ],
+          "default": true,
+          "keyHash": [
+            "2417851639229258349412352"
+          ]
+        },
+        "103": {
+          "keyName": "→",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            75
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            79
+          ],
+          "default": true,
+          "keyHash": [
+            "604462909807314587353088"
+          ]
+        },
+        "104": {
+          "keyName": "0",
+          "width": 145,
+          "height": 70,
+          "left": 25,
+          "top": 15,
+          "packetIndex": [
+            94
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            98
+          ],
+          "default": true,
+          "keyEmpty": [
+            "keyboard-key-empty"
+          ],
+          "keySpace": "keyboard-key wide",
+          "keyHash": [
+            "316912650057057350374175801344"
+          ]
+        },
+        "105": {
+          "keyName": ",",
+          "width": 65,
+          "height": 70,
+          "left": 15,
+          "top": 15,
+          "packetIndex": [
+            95
+          ],
+          "color": {
+            "red": 0,
+            "green": 255,
+            "blue": 255
+          },
+          "keyData": [
+            99
+          ],
+          "default": true,
+          "keyHash": [
+            "633825300114114700748351602688"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This adds a German (ISO) keyboard layout for the Corsair K60 RGB PRO Low Profile
(USB 1b1c:1bad). As far as I can tell it's the first non-US layout for this
device. It's a single new file, `database/keyboard/k60rgbprolp-de.json`.

## What changed
I built the DE file from the existing US file (`k60rgbprolp.json`) and followed
the same ISO convention already used by `k100-de`, `k95platinum-de` and
`k70mk2-de`. Concretely:

- Removed `\ |` (keyData 49).
- Added `# '` (keyData 50) on the home row, right before Enter.
- Added `< >` (keyData 100) on the bottom row, right after the left Shift.
- Switched to QWERTZ by swapping the Z and Y labels. Only the labels change, the
  keyData stays the same.
- Applied the German labels (^°, ß, ´, Ü, Ö, Ä and so on).
- Narrowed the ISO Enter and the left Shift by one grid column (`wide3` to
  `wide`) and added two spacer cells in front of the right-hand cluster on the
  Tab row. That keeps the nav block and the numpad lined up with the US layout.

I kept `version` at `1`, same as the US base, which matches how the other `-de`
files are done.

## Testing
I tested this on real hardware (CachyOS, OpenLinkHub 0.8.9):

- The keyboard is detected and switches cleanly between US and DE in the
  dashboard.
- I checked the per-key mapping by hand, including QWERTZ Z/Y and both new ISO
  keys. Everything lands on the correct physical key.
- I verified the LED indices for the two new keys on the device itself. `# '`
  (keyData 50) maps to packetIndex 46 and `< >` (keyData 100) maps to packetIndex
  96. Both light up the right physical key.
- The numpad and the nav cluster render as one solid, aligned block, matching the
  US layout column for column.
- Per-key and rainbow lighting look correct.

## Pre-existing quirks (inherited from the US file, not part of this PR)
A thing I noticed that already exist in the US file. I carried it over as-is rather than change them here:

- `G` (keyData 10) and the top-row `5` (keyData 34) share packetIndex 30, so `G`
  stays dark. This is already the case in `k60rgbprolp.json`. Happy to open a
  separate issue or PR to work out the correct LED index for `G` if that's
  useful.