### PR TITLE
Add Corsair Harpoon RGB Wireless dongle (1b1c:1b65)

### DIFF
--- a/99-openlinkhub.rules
+++ b/99-openlinkhub.rules
@@ -173,4 +173,5 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="2b31", MODE="0660
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="1bad", MODE="0660", OWNER="openlinkhub"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="2e95", ATTRS{idProduct}=="434d", MODE="0660", OWNER="openlinkhub"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="2e95", ATTRS{idProduct}=="434e", MODE="0660", OWNER="openlinkhub"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="1b65", MODE="0660", OWNER="openlinkhub"
 KERNEL=="uinput", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput", OWNER="openlinkhub"

--- a/src/devices/devices.go
+++ b/src/devices/devices.go
@@ -846,6 +846,7 @@ var deviceRegisterMap = map[uint16]Product{
 	7078:  {1, 0, "SLIPSTREAM WIRELESS", nil, slipstream.Init},             // SLIPSTREAM WIRELESS USB Receiver
 	11008: {1, 0, "SLIPSTREAM WIRELESS", nil, slipstream.Init},             // SLIPSTREAM WIRELESS USB Receiver
 	11035: {1, 0, "SLIPSTREAM WIRELESS", nil, slipstreamV2.Init},           // SLIPSTREAM WIRELESS V2 USB Receiver
+	7013:  {1, 0, "SLIPSTREAM WIRELESS", nil, slipstream.Init}, 			// CORSAIR HARPOON RGB WIRELESS Dongle
 	11050: {1, 0, "SABRE V2 PRO DONGLE", nil, sabrev2prodongle.Init},       // Sabre v2 Pro Ultralight Wireless Dongle
 	7041:  {1, 0, "DARK CORE RGB PRO Gaming Dongle", nil, slipstream.Init}, // DARK CORE RGB PRO Gaming Dongle
 	10754: {4, 0, "VIRTUOSO MAX WIRELESS", nil, virtuosomaxdongle.Init},    // VIRTUOSO MAX WIRELESS


### PR DESCRIPTION
## Summary
 
This adds support for the Corsair Harpoon RGB Wireless dongle (USB 1b1c:1b65). The mouse itself is already supported over USB, but the dedicated wireless receiver wasn't registered, so it only worked wired. As far as I can tell the dongle speaks the same SLIPSTREAM protocol as the other receivers, so no new driver was needed. It's a two-line change across two files.
 
## What changed
 
The Harpoon Wireless dongle (product ID `0x1b65` / 7013) wasn't in the device map, so OpenLinkHub never opened it. I registered it as a SLIPSTREAM receiver, following the same convention already used by the other Slipstream dongles (e.g. the Dark Core RGB PRO dongle). Concretely:
 
* Registered `7013` to `slipstream.Init` in `src/devices/devices.go`. Because the dongle uses the SLIPSTREAM protocol, the existing paired-device path picks up the Harpoon (`case 7006`) and drives it through the existing `harpoonW` driver. No new device code.
* Added the matching udev rule for `1b1c:1b65` in `99-openlinkhub.rules`, same format as the other entries.
I reused the existing `harpoonW` driver as-is. The wireless mouse was already implemented as a Slipstream child, it just never got reached because the receiver itself wasn't registered.
 
## Testing
 
I tested this on real hardware (CachyOS, OpenLinkHub 0.8.9):
 
* The dongle is detected on plug-in and the Harpoon RGB shows up in the dashboard.
* The mouse works wirelessly through the dongle — same feature set as the existing wired mode, since it goes through the same driver.
* I built from source and ran the patched binary directly to confirm the dongle is picked up, and verified the same through the packaged (AUR) build.
* RGB and DPI settings apply correctly to the paired mouse.
 