### PR TITLE
lcd: exclude decoded frame data from JSON output

### DIFF
--- a/src/devices/lcd/lcd.go
+++ b/src/devices/lcd/lcd.go
@@ -93,8 +93,8 @@ var (
 type ImageData struct {
 	Name           string
 	Frames         int
-	Buffer         []Frames
-	PalettedFrames []*image.Paletted
+	Buffer         []Frames          `json:"-"`
+	PalettedFrames []*image.Paletted `json:"-"`
 }
 
 type Frames struct {


### PR DESCRIPTION
ImageData.PalettedFrames holds the fully decoded pixel buffers of an LCD
animation and carries no json tag, so every device serialization walks
it. With a 121 frame animation loaded, GET /api/devices/ returns 38 MB
of base64 encoded framebuffers, and the web UI polls that endpoint on a
three second interval.

Each request marshals the entire response into memory before writing it,
so the transient allocation ratchets the heap high water mark up and the
runtime never gives it back. Left running overnight this reaches 50 GB
resident with the collector burning several cores.

Commit 8f7033d8 ("exclude lcd bytes from json outputs") already excluded
Frames.Buffer for exactly this reason. PalettedFrames was introduced
later by 543e6686 ("animation background dispose, frame dispose, resize
issue") and missed the same treatment. Tag Buffer as well, since every
field of Frames is already excluded and it only emitted a run of empty
objects.

Neither field is read by the web UI or the templates; both are consumed
only by the animation code.
