### PR TITLE
build: allow -fno-strict-overflow from pkg-config

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,4 +28,9 @@ jobs:
       - name: Install dependencies
         run: go get .
       - name: Build
+        # libpipewire-0.3.pc advertises -fno-strict-overflow, which is not on
+        # cgo's list of accepted compiler flags, so pkg-config output alone
+        # fails the build once the runner image ships a recent enough pipewire.
+        env:
+          CGO_CFLAGS_ALLOW: -fno-strict-overflow
         run: go build -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM golang:1.25.0-bookworm AS build
 ARG GIT_TAG
 ENV DEBIAN_FRONTEND=noninteractive
+# libpipewire-0.3.pc advertises -fno-strict-overflow, which is not on cgo's
+# list of accepted compiler flags, so pkg-config output alone fails the build.
+ENV CGO_CFLAGS_ALLOW=-fno-strict-overflow
 RUN apt-get update && apt-get install -y libudev-dev i2c-tools libpipewire-0.3-dev pkg-config
 RUN mkdir -p /opt/OpenLinkHub
 


### PR DESCRIPTION
libpipewire-0.3.pc advertises -fno-strict-overflow, which is not on cgo's list of accepted compiler flags, so building src/audio straight from pkg-config output fails with "invalid flag in pkg-config --cflags".

The README already tells people to set CGO_CFLAGS_ALLOW by hand, but the Dockerfile and the CI workflow both call go build without it. Those only pass today because bookworm and the runner image still ship a pipewire predating the flag; they break as soon as either moves forward. Set it in both so the automated builds do not depend on that.