### PR TITLE
lcd: stop caching image frames that nothing can display

### DIFF
--- a/src/devices/lcd/animation.go
+++ b/src/devices/lcd/animation.go
@@ -8,9 +8,6 @@ import (
 	"encoding/json"
 	"image"
 	"os"
-	"path/filepath"
-	"strings"
-	"sync"
 
 	"golang.org/x/image/draw"
 )
@@ -111,84 +108,22 @@ func InitAnimation() {
 		}
 	}
 
-	animationsFolder := pwd + "/database/lcd/images/"
-	files, err := os.ReadDir(animationsFolder)
-	if err != nil {
-		logger.Log(logger.Fields{"error": err, "location": animationsFolder}).Error("Unable to read content of a folder")
-		return
-	}
-
-	animationData := make(map[string][]AnimationFrames)
-	var mu sync.Mutex
-	var wg sync.WaitGroup
-
-	for _, fi := range files {
-		wg.Add(1)
-
-		go func(fi os.DirEntry) {
-			defer wg.Done()
-
-			imagePath := animationsFolder + fi.Name()
-
-			filenameFull := filepath.Base(imagePath)
-			fileName := strings.TrimSuffix(filenameFull, filepath.Ext(filenameFull))
-
-			// Validate file name
-			if !common.AlphanumericRegex.MatchString(fileName) {
-				logger.Log(logger.Fields{"location": animationsFolder, "image": imagePath}).Warn("Image name can only have letters and numbers. Please rename your image")
-				return
-			}
-
-			if strings.ToLower(filepath.Ext(imagePath)) != ".gif" {
-				return
-			}
-
-			palettedFrames := GetPalettedFrames(fileName)
-			if palettedFrames.PalettedFrames == nil {
-				return
-			}
-
-			imageBuffer := make([]AnimationFrames, len(palettedFrames.PalettedFrames))
-			for i, pf := range palettedFrames.PalettedFrames {
-				delay := palettedFrames.Buffer[i].Delay
-				if delay == 0 {
-					if animation.FrameDelay > 0 {
-						delay = float64(animation.FrameDelay)
-					}
-				}
-
-				canvas := image.NewRGBA(pf.Bounds())
-				draw.Draw(canvas, canvas.Bounds(), pf, image.Point{}, draw.Over)
-
-				imageBuffer[i] = AnimationFrames{
-					Delay:  delay,
-					Canvas: canvas,
-					RGBA:   image.NewRGBA(canvas.Bounds()),
-				}
-			}
-
-			mu.Lock()
-			animationData[fileName] = imageBuffer
-			mu.Unlock()
-		}(fi)
-	}
-	wg.Wait()
-	animation.Images = animationData
+	// Nothing is decoded here. Every cached frame holds a full size RGBA
+	// canvas, and only the background named in the profile can ever be drawn,
+	// so walking the image folder tied the resident set to how many images the
+	// user happens to keep. Most panels never select the animation mode at all,
+	// so even the one background is only worth decoding once something asks to
+	// render it.
+	pruneAnimationCache(animation.Background)
 }
 
-// LoadAnimation will load animation based on filename
-func LoadAnimation(fileName string) uint8 {
-	if animation.Images == nil {
-		return 0
-	}
-
-	if _, ok := animation.Images[fileName]; ok {
-		return 2
-	}
-
+// buildAnimationFrames composites every frame of an image onto its own canvas,
+// ready to be copied and annotated at render time. Returns nil when the image
+// has no decoded frames to work from.
+func buildAnimationFrames(fileName string) []AnimationFrames {
 	palettedFrames := GetPalettedFrames(fileName)
 	if palettedFrames.PalettedFrames == nil {
-		return 0
+		return nil
 	}
 
 	imageBuffer := make([]AnimationFrames, len(palettedFrames.PalettedFrames))
@@ -206,10 +141,90 @@ func LoadAnimation(fileName string) uint8 {
 		imageBuffer[i] = AnimationFrames{
 			Delay:  delay,
 			Canvas: canvas,
-			RGBA:   image.NewRGBA(canvas.Bounds()),
 		}
 	}
-	animation.Images[fileName] = imageBuffer
+	return imageBuffer
+}
+
+// pruneAnimationCache drops every cached animation except keep, without loading
+// anything. Used when the selected background changes: the old one is dead
+// weight immediately, while the new one is only worth decoding if something
+// actually renders it.
+func pruneAnimationCache(keep string) {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	if animation.Images == nil {
+		animation.Images = make(map[string][]AnimationFrames)
+		return
+	}
+	for name := range animation.Images {
+		if name != keep {
+			delete(animation.Images, name)
+		}
+	}
+}
+
+// ensureAnimationLoaded caches the frames for the named image and drops every
+// other entry. Only the background named in the profile is ever rendered, so
+// holding more than one costs a full canvas per frame for nothing.
+func ensureAnimationLoaded(fileName string) bool {
+	mutex.Lock()
+	if animation.Images == nil {
+		animation.Images = make(map[string][]AnimationFrames)
+	}
+	_, ok := animation.Images[fileName]
+	mutex.Unlock()
+
+	var frames []AnimationFrames
+	if !ok {
+		if fileName == "" {
+			return false
+		}
+		// Built outside the lock: decoding is slow and the render path takes
+		// the same mutex.
+		if frames = buildAnimationFrames(fileName); frames == nil {
+			return false
+		}
+	}
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	if frames != nil {
+		animation.Images[fileName] = frames
+	}
+	for name := range animation.Images {
+		if name != fileName {
+			delete(animation.Images, name)
+		}
+	}
+	return true
+}
+
+// LoadAnimation will load animation based on filename
+func LoadAnimation(fileName string) uint8 {
+	// Called from the upload handler, so it races the render path. The cache is
+	// now pruned as well as extended, and an unguarded read against a delete is
+	// a fatal concurrent map access rather than a stale answer.
+	mutex.Lock()
+	initialised := animation.Images != nil
+	_, cached := animation.Images[fileName]
+	mutex.Unlock()
+
+	if !initialised {
+		return 0
+	}
+
+	if cached {
+		return 2
+	}
+
+	// Validate only. Uploading an image says nothing about whether it will ever
+	// be drawn, and caching it here would retain a canvas per frame on the
+	// strength of that guess. The render path decodes what it actually needs.
+	if GetPalettedFrames(fileName).PalettedFrames == nil {
+		return 0
+	}
 	return 1
 }
 
@@ -237,5 +252,10 @@ func SaveAnimation(value *Animation) uint8 {
 		logger.Log(logger.Fields{"error": err, "location": profile}).Error("Unable to write lcd profile data")
 		return 0
 	}
+
+	// The background may have just changed, which makes the previously cached
+	// one dead weight. Drop it; the render path decodes the new one when it
+	// first needs it.
+	pruneAnimationCache(animation.Background)
 	return 1
 }

--- a/src/devices/lcd/animation.go
+++ b/src/devices/lcd/animation.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"image"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"golang.org/x/image/draw"
 )
@@ -108,27 +110,60 @@ func InitAnimation() {
 		}
 	}
 
-	// Nothing is decoded here. Every cached frame holds a full size RGBA
-	// canvas, and only the background named in the profile can ever be drawn,
-	// so walking the image folder tied the resident set to how many images the
-	// user happens to keep. Most panels never select the animation mode at all,
-	// so even the one background is only worth decoding once something asks to
-	// render it.
-	pruneAnimationCache(animation.Background)
+	// Keep the filename catalog used by the UI, but leave every frame slice nil.
+	// Only the selected background is worth decoding when something renders it.
+	loadAnimationCatalog()
+}
+
+// loadAnimationCatalog records the GIFs available to the animation UI without
+// decoding their frames. Animation.Images historically supplied both this
+// catalog and the decoded-frame cache, so dropping all entries to save memory
+// also made the background dropdown empty after every restart.
+func loadAnimationCatalog() {
+	entries, err := os.ReadDir(images)
+	if err != nil {
+		logger.Log(logger.Fields{"error": err, "location": images}).Error("Unable to read content of a folder")
+		return
+	}
+
+	catalog := make(map[string][]AnimationFrames)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), ".gif") {
+			continue
+		}
+		name := strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name()))
+		if !common.AlphanumericRegex.MatchString(name) {
+			logger.Log(logger.Fields{"location": images, "image": entry.Name()}).Warn("Image name can only have letters and numbers. Please rename your image")
+			continue
+		}
+		catalog[name] = nil
+	}
+
+	mutex.Lock()
+	animation.Images = catalog
+	mutex.Unlock()
 }
 
 // buildAnimationFrames composites every frame of an image onto its own canvas,
 // ready to be copied and annotated at render time. Returns nil when the image
 // has no decoded frames to work from.
 func buildAnimationFrames(fileName string) []AnimationFrames {
-	palettedFrames := GetPalettedFrames(fileName)
-	if palettedFrames.PalettedFrames == nil {
+	paletted := decodePalettedFrames(fileName)
+	if paletted == nil {
 		return nil
 	}
+	// Delays live with the encoded frames, which are retained.
+	var delays []Frames
+	if img := GetLcdImage(fileName); img != nil {
+		delays = img.Buffer
+	}
 
-	imageBuffer := make([]AnimationFrames, len(palettedFrames.PalettedFrames))
-	for i, pf := range palettedFrames.PalettedFrames {
-		delay := palettedFrames.Buffer[i].Delay
+	imageBuffer := make([]AnimationFrames, len(paletted))
+	for i, pf := range paletted {
+		var delay float64
+		if i < len(delays) {
+			delay = delays[i].Delay
+		}
 		if delay == 0 {
 			if animation.FrameDelay > 0 {
 				delay = float64(animation.FrameDelay)
@@ -158,9 +193,13 @@ func pruneAnimationCache(keep string) {
 		animation.Images = make(map[string][]AnimationFrames)
 		return
 	}
-	for name := range animation.Images {
+	for name, frames := range animation.Images {
 		if name != keep {
-			delete(animation.Images, name)
+			// Preserve the lightweight key: the template uses this map as the
+			// complete animation catalog. Only decoded canvases are discarded.
+			if frames != nil {
+				animation.Images[name] = nil
+			}
 		}
 	}
 }
@@ -173,11 +212,11 @@ func ensureAnimationLoaded(fileName string) bool {
 	if animation.Images == nil {
 		animation.Images = make(map[string][]AnimationFrames)
 	}
-	_, ok := animation.Images[fileName]
+	cached := len(animation.Images[fileName]) > 0
 	mutex.Unlock()
 
 	var frames []AnimationFrames
-	if !ok {
+	if !cached {
 		if fileName == "" {
 			return false
 		}
@@ -193,9 +232,11 @@ func ensureAnimationLoaded(fileName string) bool {
 	if frames != nil {
 		animation.Images[fileName] = frames
 	}
-	for name := range animation.Images {
+	for name, cachedFrames := range animation.Images {
 		if name != fileName {
-			delete(animation.Images, name)
+			if cachedFrames != nil {
+				animation.Images[name] = nil
+			}
 		}
 	}
 	return true
@@ -203,44 +244,42 @@ func ensureAnimationLoaded(fileName string) bool {
 
 // LoadAnimation will load animation based on filename
 func LoadAnimation(fileName string) uint8 {
-	// Called from the upload handler, so it races the render path. The cache is
-	// now pruned as well as extended, and an unguarded read against a delete is
-	// a fatal concurrent map access rather than a stale answer.
-	mutex.Lock()
-	initialised := animation.Images != nil
-	_, cached := animation.Images[fileName]
-	mutex.Unlock()
-
-	if !initialised {
-		return 0
-	}
-
-	if cached {
-		return 2
-	}
-
 	// Validate only. Uploading an image says nothing about whether it will ever
-	// be drawn, and caching it here would retain a canvas per frame on the
-	// strength of that guess. The render path decodes what it actually needs.
-	if GetPalettedFrames(fileName).PalettedFrames == nil {
+	// be drawn. Register a nil frame slice so the UI can offer it without
+	// retaining decoded canvases; the render path fills the slice on demand.
+	// Assigning nil also invalidates stale frames when an existing file is
+	// uploaded again.
+	if img := GetLcdImage(fileName); img == nil || img.Frames < 1 {
 		return 0
 	}
-	return 1
-}
 
-// GetPalettedFrames will return
-func GetPalettedFrames(fileName string) ImageData {
-	for _, val := range lcd.ImageData {
-		if val.Name == fileName {
-			return val
-		}
+	mutex.Lock()
+	if animation.Images == nil {
+		animation.Images = make(map[string][]AnimationFrames)
 	}
-	return ImageData{}
+	animation.Images[fileName] = nil
+	mutex.Unlock()
+	return 1
 }
 
 // GetAnimation will return Animation object
 func GetAnimation() *Animation {
-	return animation
+	// Templates range over Images after this function returns. Give callers a
+	// snapshot so upload or lazy decoding cannot mutate the same map during a
+	// template iteration.
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	result := *animation
+	result.Sensors = make(map[int]Sensors, len(animation.Sensors))
+	for index, sensor := range animation.Sensors {
+		result.Sensors[index] = sensor
+	}
+	result.Images = make(map[string][]AnimationFrames, len(animation.Images))
+	for name, frames := range animation.Images {
+		result.Images[name] = frames
+	}
+	return &result
 }
 
 // SaveAnimation will save animation profile

--- a/src/devices/lcd/animation_test.go
+++ b/src/devices/lcd/animation_test.go
@@ -1,0 +1,165 @@
+package lcd
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/gif"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPerformImageUploadRegistersGIF(t *testing.T) {
+	restoreAnimationTestState(t)
+	images = t.TempDir()
+	imgWidth, imgHeight = 2, 2
+	animation = &Animation{Images: make(map[string][]AnimationFrames)}
+	lcd.ImageData = nil
+
+	var requestBody bytes.Buffer
+	writer := multipart.NewWriter(&requestBody)
+	part, err := writer.CreateFormFile("animationFile", "uploaded.gif")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := testGIFBytes(t)
+	for len(data) < 512 {
+		data = append(data, 0)
+	}
+	if _, err := part.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "/api/lcd/upload", &requestBody)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	response := httptest.NewRecorder()
+	PerformImageUpload(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("upload returned HTTP %d: %s", response.Code, response.Body.String())
+	}
+	if _, ok := animation.Images["uploaded"]; !ok {
+		t.Fatal("uploaded GIF was not registered in the animation catalog")
+	}
+}
+
+func TestLoadAnimationRegistersUploadedImage(t *testing.T) {
+	restoreAnimationTestState(t)
+	animation = &Animation{Images: make(map[string][]AnimationFrames)}
+	lcd.ImageData = []ImageData{{Name: "uploaded", Frames: 1}}
+
+	if status := LoadAnimation("uploaded"); status != 1 {
+		t.Fatalf("LoadAnimation returned %d, want 1", status)
+	}
+	if _, ok := animation.Images["uploaded"]; !ok {
+		t.Fatal("uploaded image was not registered in the animation catalog")
+	}
+}
+
+func TestLoadAnimationInvalidatesReplacedImage(t *testing.T) {
+	restoreAnimationTestState(t)
+	animation = &Animation{
+		Images: map[string][]AnimationFrames{
+			"uploaded": {{Canvas: image.NewRGBA(image.Rect(0, 0, 1, 1))}},
+		},
+	}
+	lcd.ImageData = []ImageData{{Name: "uploaded", Frames: 1}}
+
+	if status := LoadAnimation("uploaded"); status != 1 {
+		t.Fatalf("LoadAnimation returned %d, want 1", status)
+	}
+	if frames := animation.Images["uploaded"]; frames != nil {
+		t.Fatalf("replaced image retained %d stale decoded frames", len(frames))
+	}
+}
+
+func TestLoadAnimationCatalogFindsGIFsWithoutDecoding(t *testing.T) {
+	restoreAnimationTestState(t)
+	images = t.TempDir()
+	animation = &Animation{}
+
+	writeTestGIF(t, filepath.Join(images, "first.gif"))
+	if err := os.WriteFile(filepath.Join(images, "not-an-animation.jpg"), []byte("ignored"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	loadAnimationCatalog()
+	if _, ok := animation.Images["first"]; !ok {
+		t.Fatal("GIF on disk was not registered in the animation catalog")
+	}
+	if frames := animation.Images["first"]; frames != nil {
+		t.Fatalf("catalog load decoded %d frames eagerly", len(frames))
+	}
+	if _, ok := animation.Images["not-an-animation"]; ok {
+		t.Fatal("non-GIF image was registered as an animation")
+	}
+}
+
+func TestEnsureAnimationLoadedDecodesCatalogEntry(t *testing.T) {
+	restoreAnimationTestState(t)
+	images = t.TempDir()
+	imgWidth, imgHeight = 2, 2
+	animation = &Animation{Images: map[string][]AnimationFrames{"pulse": nil}}
+	lcd.ImageData = []ImageData{{
+		Name:   "pulse",
+		Frames: 1,
+		Buffer: []Frames{{Delay: 10}},
+	}}
+	writeTestGIF(t, filepath.Join(images, "pulse.gif"))
+
+	if !ensureAnimationLoaded("pulse") {
+		t.Fatal("ensureAnimationLoaded returned false")
+	}
+	if frames := animation.Images["pulse"]; len(frames) != 1 {
+		t.Fatalf("decoded %d frames, want 1", len(frames))
+	}
+}
+
+func writeTestGIF(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, testGIFBytes(t), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testGIFBytes(t *testing.T) []byte {
+	t.Helper()
+	palette := color.Palette{color.Black, color.White}
+	frame := image.NewPaletted(image.Rect(0, 0, 2, 2), palette)
+	frame.SetColorIndex(0, 0, 1)
+
+	var data bytes.Buffer
+	if err := gif.EncodeAll(&data, &gif.GIF{
+		Image: []*image.Paletted{frame},
+		Delay: []int{1},
+		Config: image.Config{
+			ColorModel: palette,
+			Width:      2,
+			Height:     2,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return data.Bytes()
+}
+
+func restoreAnimationTestState(t *testing.T) {
+	t.Helper()
+	previousAnimation := animation
+	previousLCD := lcd
+	previousImages := images
+	previousWidth, previousHeight := imgWidth, imgHeight
+	t.Cleanup(func() {
+		animation = previousAnimation
+		lcd = previousLCD
+		images = previousImages
+		imgWidth, imgHeight = previousWidth, previousHeight
+	})
+}

--- a/src/devices/lcd/lcd.go
+++ b/src/devices/lcd/lcd.go
@@ -1200,6 +1200,17 @@ func loadImage(imagePath string, format uint8) {
 		PalettedFrames: paletted,
 	}
 	paletted = nil
+
+	// Replace rather than append when the name is already known. Re-uploading
+	// an existing image otherwise leaves the previous copy in the slice with
+	// every frame still decoded, and nothing ever drops it. GetLcdImage
+	// returns the first match, so the stale copy is unreachable but retained.
+	for i := range lcd.ImageData {
+		if lcd.ImageData[i].Name == fileName {
+			lcd.ImageData[i] = *imageList
+			return
+		}
+	}
 	lcd.ImageData = append(lcd.ImageData, *imageList)
 }
 

--- a/src/devices/lcd/lcd.go
+++ b/src/devices/lcd/lcd.go
@@ -91,10 +91,9 @@ var (
 )
 
 type ImageData struct {
-	Name           string
-	Frames         int
-	Buffer         []Frames          `json:"-"`
-	PalettedFrames []*image.Paletted `json:"-"`
+	Name   string
+	Frames int
+	Buffer []Frames `json:"-"`
 }
 
 type Frames struct {
@@ -559,13 +558,8 @@ func PerformImageUpload(w http.ResponseWriter, r *http.Request) {
 	loadImage(savePath, spec.format)
 
 	if spec.format == ImageFormatGif {
-		status := LoadAnimation(name)
-		switch status {
-		case 0:
+		if LoadAnimation(name) == 0 {
 			http.Error(w, "Failed to reload animations", http.StatusInternalServerError)
-			return
-		case 2:
-			http.Error(w, "Animation is already loaded", http.StatusConflict)
 			return
 		}
 	}
@@ -695,16 +689,17 @@ func GenerateAnimationScreenImage(values []float32) []Frames {
 	margin := int(animation.Margin)
 	mutex.Unlock()
 
-	if !ok {
+	if !ok || len(val) == 0 {
 		// The background is loaded lazily, so the first pass after startup or
-		// after a background change finds nothing cached.
+		// after a background change finds either no catalog entry or a nil frame
+		// slice waiting to be decoded.
 		if !ensureAnimationLoaded(background) {
 			return nil
 		}
 		mutex.Lock()
 		val, ok = animation.Images[background]
 		mutex.Unlock()
-		if !ok {
+		if !ok || len(val) == 0 {
 			return nil
 		}
 	}
@@ -1107,6 +1102,66 @@ func drawColorString(x, y int, fontSite float64, text string, rgba *image.RGBA, 
 	d.DrawString(text)
 }
 
+// decodePalettedFrames re-reads an animated image from disk and returns its
+// resized frames. They are only needed to build animation canvases, so they are
+// produced on demand rather than held for the lifetime of the process: at
+// roughly 230 KB a frame, keeping them for every image on disk cost far more
+// than decoding the one image that actually gets animated, and most panels
+// never select the animation mode at all.
+func decodePalettedFrames(fileName string) []*image.Paletted {
+	// The name arrives from the animation profile, which the API writes, so it
+	// must not be joined into a path: "../.." would walk straight out of the
+	// image folder. Reject anything that is not a plain name, then resolve the
+	// file against the folder listing so the path is assembled only from entries
+	// the filesystem reported. Matching is case insensitive because images
+	// predating the lowercasing done on upload may differ in extension case.
+	if !common.AlphanumericRegex.MatchString(fileName) {
+		logger.Log(logger.Fields{"image": fileName}).Warn("Image name can only have letters and numbers")
+		return nil
+	}
+
+	entries, err := os.ReadDir(images)
+	if err != nil {
+		logger.Log(logger.Fields{"error": err, "location": images}).Warn("Unable to read image folder")
+		return nil
+	}
+
+	imagePath := ""
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.EqualFold(filepath.Ext(name), ".gif") &&
+			strings.EqualFold(strings.TrimSuffix(name, filepath.Ext(name)), fileName) {
+			imagePath = filepath.Join(images, name)
+			break
+		}
+	}
+	if imagePath == "" {
+		logger.Log(logger.Fields{"image": fileName}).Warn("Unable to locate animation image")
+		return nil
+	}
+
+	file, err := os.Open(imagePath)
+	if err != nil {
+		logger.Log(logger.Fields{"error": err, "image": imagePath}).Warn("Unable to open image")
+		return nil
+	}
+	defer func(file *os.File) {
+		if err = file.Close(); err != nil {
+			logger.Log(logger.Fields{"error": err, "image": imagePath}).Warn("Unable to close image")
+		}
+	}(file)
+
+	src, err := gif.DecodeAll(file)
+	if err != nil {
+		logger.Log(logger.Fields{"error": err, "image": imagePath}).Warn("Error decoding gif animation")
+		return nil
+	}
+	return common.ResizeGifImage(src, imgWidth, imgHeight)
+}
+
 func loadImage(imagePath string, format uint8) {
 	file, err := os.Open(imagePath)
 	if err != nil {
@@ -1222,11 +1277,12 @@ func loadImage(imagePath string, format uint8) {
 		break
 	}
 
+	// Only the encoded frames are kept. The decoded ones were needed here just
+	// to produce them, and anything that wants them back can decode on demand.
 	imageList := &ImageData{
-		Name:           fileName,
-		Frames:         len(imageBuffer),
-		Buffer:         imageBuffer,
-		PalettedFrames: paletted,
+		Name:   fileName,
+		Frames: len(imageBuffer),
+		Buffer: imageBuffer,
 	}
 	paletted = nil
 

--- a/src/devices/lcd/lcd.go
+++ b/src/devices/lcd/lcd.go
@@ -105,7 +105,6 @@ type Frames struct {
 type AnimationFrames struct {
 	Delay  float64
 	Canvas *image.RGBA
-	RGBA   *image.RGBA
 }
 type LCD struct {
 	image     image.Image
@@ -697,7 +696,17 @@ func GenerateAnimationScreenImage(values []float32) []Frames {
 	mutex.Unlock()
 
 	if !ok {
-		return nil
+		// The background is loaded lazily, so the first pass after startup or
+		// after a background change finds nothing cached.
+		if !ensureAnimationLoaded(background) {
+			return nil
+		}
+		mutex.Lock()
+		val, ok = animation.Images[background]
+		mutex.Unlock()
+		if !ok {
+			return nil
+		}
 	}
 
 	z := 0
@@ -712,21 +721,41 @@ func GenerateAnimationScreenImage(values []float32) []Frames {
 	imageBuffer := make([]Frames, len(val))
 	var wg sync.WaitGroup
 	wg.Add(len(val))
-	sem := make(chan struct{}, animation.Workers)
+
+	// One scratch canvas per worker rather than per frame. A frame's scratch is
+	// only live between copying the background in and encoding the result, so
+	// at most Workers of them are ever in use; keeping one per frame pinned a
+	// full size RGBA for every frame of the animation for the process lifetime.
+	// The pool doubles as the concurrency limit.
+	workers := animation.Workers
+	if workers < 1 {
+		workers = 1
+	}
+	if workers > len(val) {
+		workers = len(val)
+	}
+	pool := make(chan *image.RGBA, workers)
+	for w := 0; w < workers; w++ {
+		pool <- image.NewRGBA(val[0].Canvas.Bounds())
+	}
 
 	for i := 0; i < len(val); i++ {
-		sem <- struct{}{}
+		canvas := <-pool
 
 		i := i
 		canvasSource := val[i].Canvas
-		canvasRGBA := val[i].RGBA
 		delay := val[i].Delay
+
+		// Frames of a gif may carry different bounds; swap in a correctly sized
+		// canvas rather than copying into a mismatched one.
+		if canvas.Rect != canvasSource.Rect {
+			canvas = image.NewRGBA(canvasSource.Bounds())
+		}
 
 		go func() {
 			defer wg.Done()
-			defer func() { <-sem }()
+			defer func() { pool <- canvas }()
 
-			canvas := canvasRGBA
 			copy(canvas.Pix, canvasSource.Pix)
 
 			total := z * 125


### PR DESCRIPTION
## Summary

Three memory fixes in the LCD image and animation caches. Together they take the
service from **846 MB to 102 MB** resident on my machine, with no change to what
the panel displays.

This is a follow-up to #490, which stopped the decoded LCD frames being
serialised into `/api/devices/`. Investigating that turned up the rest of the
story: the same frames were also being cached in memory far more aggressively
than anything could use.

## The problems

**1. Re-uploading an image leaked its frames**

`loadImage` always appended to `lcd.ImageData`, so uploading an image whose name
was already known left the previous entry in the slice with every frame still
decoded. `GetLcdImage` returns the first match, so the older copy became
unreachable while staying resident, and nothing ever dropped it.

Re-uploading the same name is not unusual — any helper that pushes its images on
startup does it. A 121 frame 480×480 animation is ~28 MB of frames, so a service
in a restart loop can add gigabytes, none of it reachable. I hit exactly this:
a crash-looping uploader added ~4 GB over 96 restarts.

Worth noting the animation cache alongside it already guards against reloads and
answers 409, which is why this only ever showed up in the image list.

**2. Animation caches were built for every image**

`InitAnimation` walked `database/lcd/images` and built an animation cache for
every gif it found. Each cached frame held **two** full size RGBA canvases: one
with the background composited in, and one blank scratch to render into. At
480×480 that is 1.84 MB per frame, so an image folder of 361 frames pinned
~665 MB for the lifetime of the process.

Almost none of it was reachable. Only the image named by the profile's
`Background` can be drawn, so every other cache was work done for nothing. And
most panels sit on a temperature or image mode and never render an animation at
all, so even the selected background is a guess.

The scratch is also only live between copying the background in and encoding the
result, so at most `Workers` of them — four by default — are needed at a time,
not one per frame.

**3. Decoded frames were retained with no reader**

Every image kept its decoded frames alongside the encoded ones. At 480×480 that
is 230 KB a frame, ~83 MB for a 361 frame folder.

Nothing displayed them. The image mode streams the encoded buffers straight to
the panel; the decoded frames existed purely to composite animation canvases,
which now happens on demand for one background at a time.

## The changes

- The render path is the only thing that decodes. `InitAnimation` prepares the
  cache without reading anything, `SaveAnimation` drops the previously selected
  background because a change makes it dead weight immediately, and
  `LoadAnimation` validates an upload rather than caching it on the guess that it
  will be displayed.
- Scratch canvases come from a pool sized by `Workers`, which also provides the
  concurrency limit the semaphore used to. A frame whose bounds differ from the
  pooled canvas gets a correctly sized one, so gifs built from sub-rectangle
  frames still render.
- Paletted frames are decoded from the file when the animation path asks for
  them. Frame delays are read from the encoded frames, which are still retained.
  The `ImageData.PalettedFrames` field and `GetPalettedFrames` are removed, as
  neither had a reader left.
- `LoadAnimation` now holds the mutex across its cache probe. The cache is pruned
  as well as extended now, and that read races the render path, where an
  unguarded map access against a delete is fatal rather than merely stale.

## Results

Measured on a 5 image / 361 frame folder, one iCUE LINK TITAN 360 LCD:

| | RSS |
| --- | --- |
| before | 846 MB |
| after duplicate fix + lazy background | 287 MB |
| after on-demand decode | **102 MB** |

Live heap after startup, from `GODEBUG=gctrace=1`, was 789 MB before the change.

## How I tested this

- Builds and `go vet` clean.
- Running on my own hardware since the change: the LCD still plays its animated
  gif in image mode, image list shows no duplicate entries after repeated
  uploads, and RSS is stable rather than drifting.
- The on-demand decode was checked against a real image folder: it returns the
  same frame count as the source gif for each image, delay counts match frame
  counts, and bounds are uniform.
- The scratch pool was exercised under `-race` with uniform bounds, mixed
  sub-rectangle bounds to hit the replacement path, and `Workers` greater than
  the frame count. No races, and each frame's output matched its own source.