### PR TITLE
fix duplicate key 71 on vanguard96 and vanguard96w to resolve inability to change G4 key bindings

### DIFF
--- a/database/keyboard/vanguard96.json
+++ b/database/keyboard/vanguard96.json
@@ -1442,7 +1442,7 @@
     "4": {
       "top": 65,
       "keys": {
-        "71": {
+        "72": {
           "keyName": "G4",
           "width": 65,
           "height": 70,
@@ -1458,7 +1458,7 @@
           "keyData": [134, 57, 56],
           "keyHash": ["21778071482940061661655974875633165533184"]
         },
-        "72": {
+        "73": {
           "keyName": "Shift",
           "width": 170,
           "height": 70,
@@ -1482,7 +1482,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "73": {
+        "74": {
           "keyName": "Z",
           "width": 65,
           "height": 70,
@@ -1502,7 +1502,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "74": {
+        "75": {
           "keyName": "X",
           "width": 65,
           "height": 70,
@@ -1522,7 +1522,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "75": {
+        "76": {
           "keyName": "C",
           "width": 65,
           "height": 70,
@@ -1542,7 +1542,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "76": {
+        "77": {
           "keyName": "V",
           "width": 65,
           "height": 70,
@@ -1562,7 +1562,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "77": {
+        "78": {
           "keyName": "B",
           "width": 65,
           "height": 70,
@@ -1582,7 +1582,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "78": {
+        "79": {
           "keyName": "N",
           "width": 65,
           "height": 70,
@@ -1602,7 +1602,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "79": {
+        "80": {
           "keyName": "M",
           "width": 65,
           "height": 70,
@@ -1622,7 +1622,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "80": {
+        "81": {
           "keyName": ", <",
           "width": 65,
           "height": 70,
@@ -1642,7 +1642,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "81": {
+        "82": {
           "keyName": ". >",
           "width": 65,
           "height": 70,
@@ -1662,7 +1662,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "82": {
+        "83": {
           "keyName": "/ ?",
           "width": 65,
           "height": 70,
@@ -1682,7 +1682,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "83": {
+        "84": {
           "keyName": "Shift",
           "width": 205,
           "height": 70,
@@ -1706,7 +1706,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "84": {
+        "85": {
           "keyName": "↑",
           "width": 65,
           "height": 70,
@@ -1726,7 +1726,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "85": {
+        "86": {
           "keyName": "1",
           "width": 65,
           "height": 70,
@@ -1746,7 +1746,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "86": {
+        "87": {
           "keyName": "2",
           "width": 65,
           "height": 70,
@@ -1766,7 +1766,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "87": {
+        "88": {
           "keyName": "3",
           "width": 65,
           "height": 70,
@@ -1786,7 +1786,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "88": {
+        "89": {
           "keyName": "Enter",
           "width": 65,
           "height": 155,
@@ -1811,7 +1811,7 @@
     },
     "5": {
       "keys": {
-        "89": {
+        "90": {
           "keyName": "G5",
           "width": 65,
           "height": 70,
@@ -1827,7 +1827,7 @@
           "keyData": [135, 57, 56],
           "keyHash": ["43556142965880123323311949751266331066368"]
         },
-        "90": {
+        "91": {
           "keyName": "Ctrl",
           "width": 90,
           "height": 70,
@@ -1851,7 +1851,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "91": {
+        "92": {
           "keyName": "Win",
           "width": 90,
           "height": 70,
@@ -1871,7 +1871,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "92": {
+        "93": {
           "keyName": "Alt",
           "width": 90,
           "height": 70,
@@ -1895,7 +1895,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "93": {
+        "94": {
           "keyName": "----------",
           "width": 455,
           "height": 70,
@@ -1916,7 +1916,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "94": {
+        "95": {
           "keyName": "Alt",
           "width": 90,
           "height": 70,
@@ -1939,7 +1939,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "95": {
+        "96": {
           "keyName": "Fn",
           "width": 90,
           "height": 70,
@@ -1960,7 +1960,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "96": {
+        "97": {
           "keyName": "ELG",
           "width": 65,
           "height": 70,
@@ -1980,7 +1980,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "97": {
+        "98": {
           "keyName": "←",
           "width": 65,
           "height": 70,
@@ -2000,7 +2000,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "98": {
+        "99": {
           "keyName": "↓",
           "width": 65,
           "height": 70,
@@ -2020,7 +2020,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "99": {
+        "100": {
           "keyName": "→",
           "width": 65,
           "height": 70,
@@ -2040,7 +2040,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "100": {
+        "101": {
           "keyName": "0",
           "width": 145,
           "height": 70,
@@ -2060,7 +2060,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "101": {
+        "102": {
           "keyName": ".",
           "width": 65,
           "height": 70,

--- a/database/keyboard/vanguard96.json
+++ b/database/keyboard/vanguard96.json
@@ -1,5 +1,5 @@
 {
-  "version": 4,
+  "version": 5,
   "uppercaseClass": "key-uppercase",
   "fontSize": 14,
   "key": "vanguard96-default",

--- a/database/keyboard/vanguard96W.json
+++ b/database/keyboard/vanguard96W.json
@@ -1448,7 +1448,7 @@
     "4": {
       "top": 65,
       "keys": {
-        "71": {
+        "72": {
           "keyName": "G4",
           "width": 65,
           "height": 70,
@@ -1464,7 +1464,7 @@
           "keyData": [134, 57, 56],
           "keyHash": ["21778071482940061661655974875633165533184"]
         },
-        "72": {
+        "73": {
           "keyName": "Shift",
           "width": 170,
           "height": 70,
@@ -1488,7 +1488,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "73": {
+        "74": {
           "keyName": "Z",
           "width": 65,
           "height": 70,
@@ -1508,7 +1508,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "74": {
+        "75": {
           "keyName": "X",
           "width": 65,
           "height": 70,
@@ -1528,7 +1528,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "75": {
+        "76": {
           "keyName": "C",
           "width": 65,
           "height": 70,
@@ -1548,7 +1548,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "76": {
+        "77": {
           "keyName": "V",
           "width": 65,
           "height": 70,
@@ -1568,7 +1568,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "77": {
+        "78": {
           "keyName": "B",
           "width": 65,
           "height": 70,
@@ -1588,7 +1588,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "78": {
+        "79": {
           "keyName": "N",
           "width": 65,
           "height": 70,
@@ -1608,7 +1608,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "79": {
+        "80": {
           "keyName": "M",
           "width": 65,
           "height": 70,
@@ -1628,7 +1628,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "80": {
+        "81": {
           "keyName": ", <",
           "width": 65,
           "height": 70,
@@ -1648,7 +1648,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "81": {
+        "82": {
           "keyName": ". >",
           "width": 65,
           "height": 70,
@@ -1668,7 +1668,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "82": {
+        "83": {
           "keyName": "/ ?",
           "width": 65,
           "height": 70,
@@ -1688,7 +1688,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "83": {
+        "84": {
           "keyName": "Shift",
           "width": 205,
           "height": 70,
@@ -1712,7 +1712,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "84": {
+        "85": {
           "keyName": "↑",
           "width": 65,
           "height": 70,
@@ -1732,7 +1732,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "85": {
+        "86": {
           "keyName": "1",
           "width": 65,
           "height": 70,
@@ -1752,7 +1752,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "86": {
+        "87": {
           "keyName": "2",
           "width": 65,
           "height": 70,
@@ -1772,7 +1772,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "87": {
+        "88": {
           "keyName": "3",
           "width": 65,
           "height": 70,
@@ -1792,7 +1792,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "88": {
+        "89": {
           "keyName": "Enter",
           "width": 65,
           "height": 155,
@@ -1817,7 +1817,7 @@
     },
     "5": {
       "keys": {
-        "89": {
+        "90": {
           "keyName": "G5",
           "width": 65,
           "height": 70,
@@ -1833,7 +1833,7 @@
           "keyData": [135, 57, 56],
           "keyHash": ["43556142965880123323311949751266331066368"]
         },
-        "90": {
+        "91": {
           "keyName": "Ctrl",
           "width": 90,
           "height": 70,
@@ -1857,7 +1857,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "91": {
+        "92": {
           "keyName": "Win",
           "width": 90,
           "height": 70,
@@ -1877,7 +1877,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "92": {
+        "93": {
           "keyName": "Alt",
           "width": 90,
           "height": 70,
@@ -1901,7 +1901,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "93": {
+        "94": {
           "keyName": "----------",
           "width": 455,
           "height": 70,
@@ -1922,7 +1922,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "94": {
+        "95": {
           "keyName": "Alt",
           "width": 90,
           "height": 70,
@@ -1945,7 +1945,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "95": {
+        "96": {
           "keyName": "Fn",
           "width": 90,
           "height": 70,
@@ -1966,7 +1966,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "96": {
+        "97": {
           "keyName": "ELG",
           "width": 65,
           "height": 70,
@@ -1986,7 +1986,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "97": {
+        "98": {
           "keyName": "←",
           "width": 65,
           "height": 70,
@@ -2006,7 +2006,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "98": {
+        "99": {
           "keyName": "↓",
           "width": 65,
           "height": 70,
@@ -2026,7 +2026,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "99": {
+        "100": {
           "keyName": "→",
           "width": 65,
           "height": 70,
@@ -2046,7 +2046,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "100": {
+        "101": {
           "keyName": "0",
           "width": 145,
           "height": 70,
@@ -2066,7 +2066,7 @@
           "secondaryActuationPoint": 35,
           "secondaryActuationResetPoint": 34
         },
-        "101": {
+        "102": {
           "keyName": ".",
           "width": 65,
           "height": 70,

--- a/database/keyboard/vanguard96W.json
+++ b/database/keyboard/vanguard96W.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "uppercaseClass": "key-uppercase",
   "fontSize": 14,
   "key": "vanguard96W-default",


### PR DESCRIPTION
## The bug
- When changing the binding of the G4 key on the Vanguard 96 Pro, the binding of the Numpad 6 key will be assigned instead. Additionally "6" will appear when you open the key binding for G4 in the description. Looking at the .json files for the default layout of the Vanguard 96 and Vanguard 96 W there is a duplicate index with "71", the numpad 6 and the G4 key. Presumably when the key bindings are updated the json file is loading the first instance of 71 which would be the numpad 6, rather than the G4 key, hence the bug.

## Repro steps
- Attempt to change key binding of G4 key to another key on Vanguard 96
- Expected: New key binding will execute when pressing G4.
- **Observed: Instead of "G4" key label in description, "6" will appear. Pressing G4 key will do nothing. Instead pressing the 6 on the numpad will execute the new binding**

## Resolution
- Change the index for the G4 key on to have +1.
- Tested locally and this resolves the issue, no impact on layout through webUI