### PR TITLE
Add support for VOID ELITE Wireless dongle PID 0x0A55

### DIFF
--- a/src/devices/devices.go
+++ b/src/devices/devices.go
@@ -870,6 +870,7 @@ var deviceRegisterMap = map[uint16]Product{
 	2626:  {3, 0, "HEADSET DONGLE", nil, headsetdongle.Init},               // Headset dongle
 	2675:  {3, 0, "HEADSET DONGLE", nil, headsetdongle.Init},               // Headset dongle
 	2641:  {3, 0, "VOID ELITE WIRELESS", nil, voidelitedongle.Init},        // Headset dongle
+	2645:  {3, 0, "VOID ELITE WIRELESS", nil, voidelitedongle.Init},        // Headset dongle (rev 0x0A55)
 	2622:  {3, 65346, "HEADSET DONGLE", nil, headsetdongle.Init},           // Headset dongle
 	2624:  {3, 65346, "HEADSET DONGLE", nil, headsetdongle.Init},           // Headset dongle
 	11015: {1, 0, "K65 PLUS WIRELESS", nil, k65plusWdongle.Init},           // K65 PLUS WIRELESS

--- a/src/devices/voidelitedongle/voidelitedongle.go
+++ b/src/devices/voidelitedongle/voidelitedongle.go
@@ -102,7 +102,7 @@ func (d *Device) createDevice() {
 // addDevices adda a mew device
 func (d *Device) addDevices() {
 	switch d.Devices.ProductId {
-	case 2641:
+	case 2641, 2645:
 		{
 			dev := voideliteW.Init(
 				d.Devices.VendorId,


### PR DESCRIPTION
## Summary

Corsair has shipped the VOID ELITE Wireless headset dongle under two different USB PIDs: `0x0A51` (2641, already supported) and `0x0A55` (2645, this PR). Both enumerate with the identical USB descriptor string `CORSAIR VOID ELITE Wireless Gaming Dongle` and use the same wire protocol — it's just a later hardware/firmware revision that got a new PID, same as the existing precedent for the generic `headsetdongle.Init` entries (2660, 2667, 2628, 2626, 2675) which already cover multiple PID revisions of other headset dongles.

Two places needed the new PID:
- `devices.go`: register `2645` against `voidelitedongle.Init`, mirroring `2641`
- `voidelitedongle.go`: `addDevices()` gates creation of the actual `VOID ELITE WIRELESS` child device on a hardcoded `ProductId` switch, so `2645` needs the same `case` as `2641` — without it, only the hidden dongle shell gets created and the headset itself never appears.

## Test plan
- [x] Built and ran locally against a real `0x0A55` dongle
- [x] Confirmed device shows up in `/api/devices/` as `VOID ELITE WIRELESS` (not just the hidden dongle shell)
- [x] Confirmed RGB zones (Logo L / Logo R) and EQ presets report correctly via the per-device API endpoint
- [x] Confirmed firmware version reports correctly